### PR TITLE
Create DnD menu only with supported actions

### DIFF
--- a/src/dndactionmenu.cpp
+++ b/src/dndactionmenu.cpp
@@ -22,10 +22,19 @@
 
 namespace Fm {
 
-DndActionMenu::DndActionMenu(QWidget* parent): QMenu(parent) {
-  copyAction = addAction(QIcon::fromTheme("edit-copy"), tr("Copy here"));
-  moveAction = addAction(tr("Move here"));
-  linkAction = addAction(tr("Create symlink here"));
+DndActionMenu::DndActionMenu(Qt::DropActions possibleActions, QWidget* parent)
+  : QMenu(parent)
+  , copyAction(nullptr)
+  , moveAction(nullptr)
+  , linkAction(nullptr)
+  , cancelAction(nullptr)
+{
+  if (possibleActions.testFlag(Qt::CopyAction))
+    copyAction = addAction(QIcon::fromTheme("edit-copy"), tr("Copy here"));
+  if (possibleActions.testFlag(Qt::MoveAction))
+    moveAction = addAction(tr("Move here"));
+  if (possibleActions.testFlag(Qt::LinkAction))
+    linkAction = addAction(tr("Create symlink here"));
   addSeparator();
   cancelAction = addAction(tr("Cancel"));
 }
@@ -34,18 +43,19 @@ DndActionMenu::~DndActionMenu() {
 
 }
 
-Qt::DropAction DndActionMenu::askUser(QPoint pos) {
-  Qt::DropAction result;
-  DndActionMenu menu;
+Qt::DropAction DndActionMenu::askUser(Qt::DropActions possibleActions, QPoint pos) {
+  Qt::DropAction result = Qt::IgnoreAction;
+  DndActionMenu menu{possibleActions};
   QAction* action = menu.exec(pos);
-  if(action == menu.copyAction)
-    result = Qt::CopyAction;
-  else if(action == menu.moveAction)
-    result = Qt::MoveAction;
-  else if(action == menu.linkAction)
-    result = Qt::LinkAction;
-  else
-    result = Qt::IgnoreAction;
+  if (nullptr != action)
+  {
+      if(action == menu.copyAction)
+          result = Qt::CopyAction;
+      else if(action == menu.moveAction)
+          result = Qt::MoveAction;
+      else if(action == menu.linkAction)
+          result = Qt::LinkAction;
+  }
   return result;
 }
 

--- a/src/dndactionmenu.h
+++ b/src/dndactionmenu.h
@@ -30,10 +30,10 @@ namespace Fm {
 class DndActionMenu : public QMenu {
 Q_OBJECT
 public:
-  explicit DndActionMenu(QWidget* parent = 0);
+  explicit DndActionMenu(Qt::DropActions possibleActions, QWidget* parent = 0);
   virtual ~DndActionMenu();
 
-  static Qt::DropAction askUser(QPoint pos);
+  static Qt::DropAction askUser(Qt::DropActions possibleActions, QPoint pos);
 
 private:
   QAction* copyAction;

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -804,7 +804,7 @@ void FolderView::childDropEvent(QDropEvent* e) {
   if(e->keyboardModifiers() == Qt::NoModifier) {
     // if no key modifiers are used, popup a menu
     // to ask the user for the action he/she wants to perform.
-    Qt::DropAction action = DndActionMenu::askUser(QCursor::pos());
+    Qt::DropAction action = DndActionMenu::askUser(e->possibleActions(), QCursor::pos());
     e->setDropAction(action);
   }
 }


### PR DESCRIPTION
see [comment](https://github.com/lxde/lxqt/issues/446#issuecomment-159903604)
> - if the DND is originated in plugin-mainmenu (QMenu), then after the drop anything can be selected, but the action is always Qt::CopyAction in dropMimeData()


OT: @PCMan shouldn't the lxde/libfm-qt repo be accesible for r/w also for other lxqt people?