### PR TITLE
Fix target language in Lithuanian translation file

### DIFF
--- a/src/translations/libfm-qt_lt_LT.ts
+++ b/src/translations/libfm-qt_lt_LT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_TW">
+<TS version="2.1" language="lt_LT">
 <context>
     <name>AppChooserDialog</name>
     <message>


### PR DESCRIPTION
The file's target language was set to "zh_TW" instead of "lt_LT".

Thanks!