### PR TITLE
Let the style engine draw the text selection rectangle.

### DIFF
--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -178,11 +178,23 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt
 
   QPalette::ColorGroup cg = opt.state & QStyle::State_Enabled ? QPalette::Normal : QPalette::Disabled;
   if(opt.state & QStyle::State_Selected) {
-    painter->fillRect(selRect, opt.palette.highlight());
+    if(!opt.widget)
+      painter->fillRect(selRect, opt.palette.highlight());
     painter->setPen(opt.palette.color(cg, QPalette::HighlightedText));
   }
   else
     painter->setPen(opt.palette.color(cg, QPalette::Text));
+
+  if (opt.state & QStyle::State_Selected || opt.state & QStyle::State_MouseOver) {
+    if (const QWidget* widget = opt.widget) { // let the style engine do it
+      QStyle* style = widget->style() ? widget->style() : qApp->style();
+      QStyleOptionViewItemV4 o(opt);
+      o.text = QString();
+      o.rect = selRect.toAlignedRect().intersected(opt.rect); // due to clipping and rounding, we might lose 1px
+      o.showDecorationSelected = true;
+      style->drawPrimitive(QStyle::PE_PanelItemViewItem, &o, painter, widget);
+    }
+  }
 
   // draw text
   for(int i = 0; i < visibleLines; ++i) {


### PR DESCRIPTION
More flexible Qt style engines, like QtCurve and Kvantum, have more elegant ways of drawing the text selection rectangle than just filling it with the highlight color. They may also have hovering/inactiveness effects. Besides, according to my experience with QStyle, it's better to leave the style related stuff to the active engine as far as possible (it's a long story).

Here is an example with Kvantum:
![selected-items](https://cloud.githubusercontent.com/assets/981076/12072129/7b5fd5da-b0e6-11e5-83d6-0845939a98f7.png)

If this PR is accepted, I'll make another one for Desktop.