### PR TITLE
Disable unused options in file search dialog

### DIFF
--- a/src/filesearch.ui
+++ b/src/filesearch.ui
@@ -270,10 +270,17 @@
           <item row="0" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QSpinBox" name="minSize"/>
+             <widget class="QSpinBox" name="minSize">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+             </widget>
             </item>
             <item>
              <widget class="QComboBox" name="minSizeUnit">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
               <property name="currentIndex">
                <number>2</number>
               </property>
@@ -311,10 +318,17 @@
           <item row="1" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QSpinBox" name="maxSize"/>
+             <widget class="QSpinBox" name="maxSize">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+             </widget>
             </item>
             <item>
              <widget class="QComboBox" name="maxSizeUnit">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
               <property name="currentIndex">
                <number>2</number>
               </property>
@@ -367,6 +381,9 @@
           </item>
           <item row="0" column="1">
            <widget class="QDateEdit" name="maxTime">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="calendarPopup">
              <bool>true</bool>
             </property>
@@ -374,6 +391,9 @@
           </item>
           <item row="1" column="1">
            <widget class="QDateEdit" name="minTime">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="calendarPopup">
              <bool>true</bool>
             </property>
@@ -442,6 +462,102 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>largerThan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>minSizeUnit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>93</x>
+     <y>84</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>403</x>
+     <y>88</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>smallerThan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>maxSize</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>96</x>
+     <y>119</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>123</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>largerThan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>minSize</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>93</x>
+     <y>84</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>88</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>smallerThan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>maxSizeUnit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>96</x>
+     <y>119</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>403</x>
+     <y>123</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>laterThan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>minTime</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>88</x>
+     <y>223</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>319</x>
+     <y>226</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>earlierThan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>maxTime</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>93</x>
+     <y>190</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>319</x>
+     <y>193</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Four options in the file search dialog are only used for the search if their check boxes are checked. This was not explicitly shown by setting their related widgets to disabled if the check boxes were not checked.

Thanks!