### PR TITLE
FolderView methods for getting and setting item delegate margins

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -389,7 +389,8 @@ FolderView::FolderView(ViewMode _mode, QWidget* parent):
   autoSelectionTimer_(nullptr),
   selChangedTimer_(nullptr),
   fileLauncher_(nullptr),
-  model_(nullptr) {
+  model_(nullptr),
+  itemDelegateMargins_(QSize(3, 3)) {
 
   iconSize_[IconMode - FirstViewMode] = QSize(48, 48);
   iconSize_[CompactMode - FirstViewMode] = QSize(24, 24);
@@ -577,7 +578,7 @@ void FolderView::updateGridSize() {
       ; // do not use grid size
   }
   if(mode == IconMode || mode == ThumbnailMode)
-    listView->setGridSize(grid + QSize(6, 6)); // a margin of 6 px for every cell
+    listView->setGridSize(grid + 2 * itemDelegateMargins_); // the default spacing is 6(=2x3) px
   else
     listView->setGridSize(grid);
   FolderItemDelegate* delegate = static_cast<FolderItemDelegate*>(listView->itemDelegateForColumn(FolderModel::ColumnFileName));
@@ -598,6 +599,13 @@ void FolderView::setIconSize(ViewMode mode, QSize size) {
 QSize FolderView::iconSize(ViewMode mode) const {
   Q_ASSERT(mode >= FirstViewMode && mode <= LastViewMode);
   return iconSize_[mode - FirstViewMode];
+}
+
+void FolderView::setMargins(QSize size) {
+  if (itemDelegateMargins_ != size.expandedTo(QSize(0, 0))) {
+    itemDelegateMargins_ = size.expandedTo(QSize(0, 0));
+    updateGridSize();
+  }
 }
 
 FolderView::ViewMode FolderView::viewMode() const {

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -133,7 +133,15 @@ protected:
 
   virtual bool eventFilter(QObject* watched, QEvent* event);
 
-  void updateGridSize(); // called when view mode, icon size, or font size is changed
+  void updateGridSize(); // called when view mode, icon size, font size or cell margin is changed
+
+  QSize getMargins() const {
+    return itemDelegateMargins_;
+  }
+
+  // sets the cell margins in the icon and thumbnail modes
+  // and calls updateGridSize() when needed
+  void setMargins(QSize size);
 
 public Q_SLOTS:
   void onItemActivated(QModelIndex index);
@@ -162,6 +170,8 @@ private:
   QTimer* autoSelectionTimer_;
   QModelIndex lastAutoSelectionIndex_;
   QTimer* selChangedTimer_;
+  // the cell margins in the icon and thumbnail modes
+  QSize itemDelegateMargins_;
 };
 
 }


### PR DESCRIPTION
This simple commit paves the way for adding an option for (minimum) icon spacing to PCManfm-qt and other apps that subclass FolderView. For now, I've used it with success to prevent large gaps from taking shape at desktop bottom (https://github.com/lxde/pcmanfm-qt/issues/97#issuecomment-170671223).