### PR TITLE
Add (folder) custom actions to foldermenu.

### DIFF
--- a/src/customaction_p.h
+++ b/src/customaction_p.h
@@ -17,37 +17,31 @@
  *
  */
 
-#ifndef FM_FILEMENU_P_H
-#define FM_FILEMENU_P_H
-
-#include "icontheme.h"
-#include <QDebug>
+#ifndef FM_CUSTOMACTION_P_H
+#define FM_CUSTOMACTION_P_H
 
 namespace Fm {
 
-class AppInfoAction : public QAction {
-  Q_OBJECT
+class CustomAction : public QAction {
 public:
-  explicit AppInfoAction(GAppInfo* app, QObject* parent = 0):
-    QAction(QString::fromUtf8(g_app_info_get_name(app)), parent),
-    appInfo_(G_APP_INFO(g_object_ref(app))) {
-    setToolTip(QString::fromUtf8(g_app_info_get_description(app)));
-    GIcon* gicon = g_app_info_get_icon(app);
-    QIcon icon = IconTheme::icon(gicon);
-    setIcon(icon);
+  explicit CustomAction(FmFileActionItem* item, QObject* parent = NULL):
+    QAction(QString::fromUtf8(fm_file_action_item_get_name(item)), parent),
+    item_(reinterpret_cast<FmFileActionItem*>(fm_file_action_item_ref(item))) {
+    const char* icon_name = fm_file_action_item_get_icon(item);
+    if(icon_name)
+      setIcon(QIcon::fromTheme(icon_name));
   }
 
-  virtual ~AppInfoAction() {
-    if(appInfo_)
-      g_object_unref(appInfo_);
+  virtual ~CustomAction() {
+    fm_file_action_item_unref(item_);
   }
 
-  GAppInfo* appInfo() const {
-    return appInfo_;
+  FmFileActionItem* item() {
+    return item_;
   }
 
 private:
-  GAppInfo* appInfo_;
+  FmFileActionItem* item_;
 };
 
 } // namespace Fm

--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -28,6 +28,7 @@
 #include "appchooserdialog.h"
 #ifdef CUSTOM_ACTIONS
 #include <libfm/fm-actions.h>
+#include "customaction_p.h"
 #endif
 #include <QMessageBox>
 #include <QDebug>
@@ -184,6 +185,11 @@ void FileMenu::createMenu(FmFileInfoList* files, FmFileInfo* info, FmPath* cwd) 
     GList* l;
     for(l=items; l; l=l->next) {
       FmFileActionItem* item = FM_FILE_ACTION_ITEM(l->data);
+      if(l == items && item
+         && !(fm_file_action_item_is_action(item)
+              && !(fm_file_action_item_get_target(item) & FM_FILE_ACTION_TARGET_CONTEXT))) {
+        addSeparator(); // before all custom actions
+      }
       addCustomActionItem(this, item);
     }
   }

--- a/src/foldermenu.h
+++ b/src/foldermenu.h
@@ -25,6 +25,9 @@
 #include <QMenu>
 #include <libfm/fm.h>
 #include "foldermodel.h"
+#ifdef CUSTOM_ACTIONS
+#include <libfm/fm-actions.h>
+#endif
 
 class QAction;
 
@@ -87,6 +90,11 @@ public:
     return view_;
   }
 
+protected:
+#ifdef CUSTOM_ACTIONS
+  void addCustomActionItem(QMenu* menu, FmFileActionItem* item);
+#endif
+
 protected Q_SLOTS:
   void onPasteActionTriggered();
   void onSelectAllActionTriggered();
@@ -97,6 +105,9 @@ protected Q_SLOTS:
   void onCaseSensitiveActionTriggered(bool checked);
   void onFolderFirstActionTriggered(bool checked);
   void onPropertiesActionTriggered();
+#ifdef CUSTOM_ACTIONS
+  void onCustomActionTrigerred();
+#endif
 
 private:
   void createSortMenu();


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/297.
The new class `CustomFolderAction` is a duplication of `CustomAction` in `filemenu_p.h` because including that header in `foldermenu.cpp` didn't seem wise. The new private header `foldermenu_p.h` is just for it.