### PR TITLE
Focus automatically on the first field of the filesearch dialog

### DIFF
--- a/src/filesearchdialog.cpp
+++ b/src/filesearchdialog.cpp
@@ -41,6 +41,8 @@ FileSearchDialog::FileSearchDialog(QStringList paths, QWidget* parent, Qt::Windo
 
   connect(ui->addPath, &QPushButton::clicked, this, &FileSearchDialog::onAddPath);
   connect(ui->removePath, &QPushButton::clicked, this, &FileSearchDialog::onRemovePath);
+
+  ui->namePatterns->setFocus();
 }
 
 FileSearchDialog::~FileSearchDialog() {


### PR DESCRIPTION
This makes it possible to use the file search dialog only with the keyboard for simple searches.