### PR TITLE
Redirect focus operation on the folderview to the actual widget

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -473,6 +473,7 @@ void FolderView::setViewMode(ViewMode _mode) {
   if(mode == DetailedListMode) {
     FolderViewTreeView* treeView = new FolderViewTreeView(this);
     connect(treeView, &FolderViewTreeView::activatedFiltered, this, &FolderView::onItemActivated);
+    setFocusProxy(treeView);
 
     view = treeView;
     treeView->setItemsExpandable(false);
@@ -492,6 +493,8 @@ void FolderView::setViewMode(ViewMode _mode) {
       connect(listView, &FolderViewListView::activatedFiltered, this, &FolderView::onItemActivated);
       view = listView;
     }
+    setFocusProxy(listView);
+
     // set our own custom delegate
     FolderItemDelegate* delegate = new FolderItemDelegate(listView);
     listView->setItemDelegateForColumn(FolderModel::ColumnFileName, delegate);


### PR DESCRIPTION
With this addition, focus operation used on the `FolderView` widget will be properly redirected to the underlying widget.

Related documentation: https://doc.qt.io/qt-5.5/qwidget.html#setFocusProxy