### PR TITLE
Fix rename dialog displaying source info twice

### DIFF
--- a/src/renamedialog.cpp
+++ b/src/renamedialog.cpp
@@ -73,8 +73,8 @@ RenameDialog::RenameDialog(FmFileInfo* src, FmFileInfo* dest, QWidget* parent, Q
   }
   else {
     infoStr = QString(tr("Type: %1\nModified: %3"))
-                .arg(QString::fromUtf8(fm_file_info_get_desc(src)))
-                .arg(QString::fromUtf8(fm_file_info_get_disp_mtime(src)));
+                .arg(QString::fromUtf8(fm_file_info_get_desc(dest)))
+                .arg(QString::fromUtf8(fm_file_info_get_disp_mtime(dest)));
   }
   ui->destInfo->setText(infoStr);
 


### PR DESCRIPTION
It displayed the same info for source and destination folder.

Thanks!