### PR TITLE
Fix DND on view mode change

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -500,6 +500,11 @@ void FolderView::setViewMode(ViewMode _mode) {
     listView->setItemDelegateForColumn(FolderModel::ColumnFileName, delegate);
     // FIXME: should we expose the delegate?
     listView->setMovement(QListView::Static);
+    /* If listView is already visible, setMovement() will lay out items again with delay
+       (see Qt, QListView::setMovement(), d->doDelayedItemsLayout()) and thus drop events
+       will remain disabled for the viewport. So, we should re-enable drop events here. */
+    if(listView->viewport()->isVisible())
+      listView->viewport()->setAcceptDrops(true);
     listView->setResizeMode(QListView::Adjust);
     listView->setWrapping(true);
     switch(mode) {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/351.

`FolderView::setViewMode()` uses `QListView::setMovement(QListView::Static)`. If listView is already visible, the latter function not only will disable the drop events for its viewport but also will cause a delayed re-layout, which will prevent accepting of drops even after enabling drop events for its parent view in the former function. This commit re-enables the drop events when listView is visible.