### PR TITLE
Fix memory leak in file open menu

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -120,7 +120,9 @@ void FileMenu::createMenu(FmFileInfoList* files, FmFileInfo* info, FmPath* cwd) 
         connect(action, &QAction::triggered, this, &FileMenu::onApplicationTriggered);
         menu->addAction(action);
       }
-      g_list_free(apps); /* don't unref GAppInfos now */
+      // unref GAppInfos here, they are still ref'ed in the AppInfoActions above
+      g_list_foreach(apps, (GFunc)g_object_unref, NULL);
+      g_list_free(apps);
     }
   }
   menu->addSeparator();


### PR DESCRIPTION
`AppInfoAction` stores a `GAppInfo` and updates the reference count in the constructor and destructor. Nevertheless, the `GAppInfo`s were later not finalized because they still were referenced from their original list.

Found by Valgrind.

Thanks!