### PR TITLE
Fix item text direction with RTL layout

### DIFF
--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -131,7 +131,10 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItemV4& opt
   QTextOption textOption;
   textOption.setAlignment(opt.displayAlignment);
   textOption.setWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
-  textOption.setTextDirection(opt.direction);
+  if (opt.text.isRightToLeft())
+    textOption.setTextDirection(Qt::RightToLeft);
+  else
+    textOption.setTextDirection(Qt::LeftToRight);
   layout.setTextOption(textOption);
   qreal height = 0;
   qreal width = 0;


### PR DESCRIPTION
Should fix https://github.com/lxde/pcmanfm-qt/issues/378.

The text direction of QTextOption should be set according to the string direction; otherwise, some item texts will be drawn incorrectly with RTL layouts.

The same change will be made to desktop later.