### PR TITLE
Silence new compiler warnings

### DIFF
--- a/src/appchoosercombobox.cpp
+++ b/src/appchoosercombobox.cpp
@@ -26,11 +26,11 @@ namespace Fm {
 
 AppChooserComboBox::AppChooserComboBox(QWidget* parent):
   QComboBox(parent),
-  defaultApp_(NULL),
+  mimeType_(NULL),
   appInfos_(NULL),
+  defaultApp_(NULL),
   defaultAppIndex_(-1),
   prevIndex_(0),
-  mimeType_(NULL),
   blockOnCurrentIndexChanged_(false) {
 
   // the new Qt5 signal/slot syntax cannot handle overloaded methods by default

--- a/src/appchooserdialog.cpp
+++ b/src/appchooserdialog.cpp
@@ -27,10 +27,10 @@ namespace Fm {
 
 AppChooserDialog::AppChooserDialog(FmMimeType* mimeType, QWidget* parent, Qt::WindowFlags f):
   QDialog(parent, f),
+  ui(new Ui::AppChooserDialog()),
   mimeType_(NULL),
-  selectedApp_(NULL),
   canSetDefault_(true),
-  ui(new Ui::AppChooserDialog()) {
+  selectedApp_(NULL) {
   ui->setupUi(this);
 
   connect(ui->appMenuView, &AppMenuView::selectionChanged, this, &AppChooserDialog::onSelectionChanged);

--- a/src/appmenuview.cpp
+++ b/src/appmenuview.cpp
@@ -26,10 +26,10 @@
 namespace Fm {
 
 AppMenuView::AppMenuView(QWidget* parent):
+  QTreeView(parent),
   model_(new QStandardItemModel()),
   menu_cache(NULL),
-  menu_cache_reload_notify(NULL),
-  QTreeView(parent) {
+  menu_cache_reload_notify(NULL) {
 
   setHeaderHidden(true);
   setSelectionMode(SingleSelection);

--- a/src/dirtreemodelitem.cpp
+++ b/src/dirtreemodelitem.cpp
@@ -25,25 +25,25 @@
 namespace Fm {
 
 DirTreeModelItem::DirTreeModelItem():
-  model_(nullptr),
+  fileInfo_(nullptr),
   folder_(nullptr),
   expanded_(false),
   loaded_(false),
-  fileInfo_(nullptr),
+  parent_(nullptr),
   placeHolderChild_(nullptr),
-  parent_(nullptr) {
+  model_(nullptr) {
 }
 
 DirTreeModelItem::DirTreeModelItem(FmFileInfo* info, DirTreeModel* model, DirTreeModelItem* parent):
-  model_(model),
-  folder_(nullptr),
-  expanded_(false),
-  loaded_(false),
   fileInfo_(fm_file_info_ref(info)),
+  folder_(nullptr),
   displayName_(QString::fromUtf8(fm_file_info_get_disp_name(info))),
   icon_(IconTheme::icon(fm_file_info_get_icon(info))),
+  expanded_(false),
+  loaded_(false),
+  parent_(parent),
   placeHolderChild_(nullptr),
-  parent_(parent) {
+  model_(model) {
 
   if(info)
     addPlaceHolderChild();

--- a/src/dirtreeview.cpp
+++ b/src/dirtreeview.cpp
@@ -30,8 +30,8 @@
 namespace Fm {
 
 DirTreeView::DirTreeView(QWidget* parent):
-  currentExpandingItem_(NULL),
-  currentPath_(NULL) {
+  currentPath_(NULL),
+  currentExpandingItem_(NULL) {
 
   setSelectionMode(QAbstractItemView::SingleSelection);
   setHeaderHidden(true);

--- a/src/execfiledialog.cpp
+++ b/src/execfiledialog.cpp
@@ -25,9 +25,9 @@ namespace Fm {
 
 ExecFileDialog::ExecFileDialog(FmFileInfo* file, QWidget* parent, Qt::WindowFlags f):
   QDialog (parent, f),
+  ui(new Ui::ExecFileDialog()),
   fileInfo_(fm_file_info_ref(file)),
-  result_(FM_FILE_LAUNCHER_EXEC_CANCEL),
-  ui(new Ui::ExecFileDialog()) {
+  result_(FM_FILE_LAUNCHER_EXEC_CANCEL) {
 
   ui->setupUi(this);
   // show file icon

--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -44,8 +44,8 @@ FileMenu::FileMenu(FmFileInfoList* files, FmFileInfo* info, FmPath* cwd, QWidget
 
 FileMenu::FileMenu(FmFileInfoList* files, FmFileInfo* info, FmPath* cwd, const QString& title, QWidget* parent):
   QMenu(title, parent),
-  fileLauncher_(NULL),
-  unTrashAction_(NULL) {
+  unTrashAction_(NULL),
+  fileLauncher_(NULL) {
   createMenu(files, info, cwd);
 }
 

--- a/src/fileoperation.cpp
+++ b/src/fileoperation.cpp
@@ -31,6 +31,7 @@ namespace Fm {
 
 FileOperation::FileOperation(Type type, FmPathList* srcFiles, QObject* parent):
   QObject(parent),
+  job_(fm_file_ops_job_new((FmFileOpType)type, srcFiles)),
   dlg(NULL),
   destPath(NULL),
   srcPaths(fm_path_list_ref(srcFiles)),
@@ -38,8 +39,7 @@ FileOperation::FileOperation(Type type, FmPathList* srcFiles, QObject* parent):
   elapsedTimer_(NULL),
   lastElapsed_(0),
   updateRemainingTime_(true),
-  autoDestroy_(true),
-  job_(fm_file_ops_job_new((FmFileOpType)type, srcFiles)) {
+  autoDestroy_(true) {
 
   g_signal_connect(job_, "ask", G_CALLBACK(onFileOpsJobAsk), this);
   g_signal_connect(job_, "ask-rename", G_CALLBACK(onFileOpsJobAskRename), this);

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -46,9 +46,9 @@ enum {
 FilePropsDialog::FilePropsDialog(FmFileInfoList* files, QWidget* parent, Qt::WindowFlags f):
   QDialog(parent, f),
   fileInfos_(fm_file_info_list_ref(files)),
+  fileInfo(fm_file_info_list_peek_head(files)),
   singleType(fm_file_info_list_is_same_type(files)),
   singleFile(fm_file_info_list_get_length(files) == 1 ? true:false),
-  fileInfo(fm_file_info_list_peek_head(files)),
   mimeType(NULL) {
 
   setAttribute(Qt::WA_DeleteOnClose);
@@ -304,7 +304,7 @@ void FilePropsDialog::initGeneralPage() {
   connect(fileSizeTimer, &QTimer::timeout, this, &FilePropsDialog::onFileSizeTimerTimeout);
   fileSizeTimer->start(600);
   g_signal_connect(deepCountJob, "finished", G_CALLBACK(onDeepCountJobFinished), this);
-  gboolean ret = fm_job_run_async(FM_JOB(deepCountJob));
+  fm_job_run_async(FM_JOB(deepCountJob));
 }
 
 /*static */ void FilePropsDialog::onDeepCountJobFinished(FmDeepCountJob* job, FilePropsDialog* pThis) {

--- a/src/filesearchdialog.cpp
+++ b/src/filesearchdialog.cpp
@@ -54,8 +54,7 @@ void FileSearchDialog::accept() {
   int n = ui->listView->count();
   if(n > 0) {
     FmSearch* search = fm_search_new();
-    int i;
-    for(i = 0; i < n; ++i) { // add directories
+    for(int i = 0; i < n; ++i) { // add directories
       QListWidgetItem* item = ui->listView->item(i);
       fm_search_add_dir(search, item->text().toLocal8Bit().constData());
     }
@@ -90,7 +89,7 @@ void FileSearchDialog::accept() {
         "application/msword;application/vnd.ms-word",
         "application/msexcel;application/vnd.ms-excel"
       };
-      for(i = 0; i < sizeof(doc_types)/sizeof(char*); ++i)
+      for(unsigned int i = 0; i < sizeof(doc_types)/sizeof(char*); ++i)
         fm_search_add_mime_type(search, doc_types[i]);
     }
 

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -34,8 +34,8 @@ namespace Fm {
 
 FolderItemDelegate::FolderItemDelegate(QAbstractItemView* view, QObject* parent):
   QStyledItemDelegate(parent ? parent : view),
-  symlinkIcon_(QIcon::fromTheme("emblem-symbolic-link")),
-  view_(view) {
+  view_(view),
+  symlinkIcon_(QIcon::fromTheme("emblem-symbolic-link")) {
 }
 
 FolderItemDelegate::~FolderItemDelegate() {

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -181,8 +181,8 @@ void FolderViewListView::activation(const QModelIndex &index) {
 
 FolderViewTreeView::FolderViewTreeView(QWidget* parent):
   QTreeView(parent),
-  layoutTimer_(nullptr),
   doingLayout_(false),
+  layoutTimer_(nullptr),
   activationAllowed_(true) {
 
   header()->setStretchLastSection(true);
@@ -388,12 +388,12 @@ void FolderViewTreeView::onSortFilterChanged() {
 FolderView::FolderView(ViewMode _mode, QWidget* parent):
   QWidget(parent),
   view(nullptr),
+  model_(nullptr),
   mode((ViewMode)0),
+  fileLauncher_(nullptr),
   autoSelectionDelay_(600),
   autoSelectionTimer_(nullptr),
   selChangedTimer_(nullptr),
-  fileLauncher_(nullptr),
-  model_(nullptr),
   itemDelegateMargins_(QSize(3, 3)) {
 
   iconSize_[IconMode - FirstViewMode] = QSize(48, 48);
@@ -656,7 +656,8 @@ bool FolderView::event(QEvent* event) {
     case QEvent::FontChange:
       updateGridSize();
       break;
-  };
+    default: break;
+  }
   return QWidget::event(event);
 }
 
@@ -830,10 +831,9 @@ void FolderView::childDropEvent(QDropEvent* e) {
     const QWidget* targetWidget = childView()->viewport();
     // these are dynamic QObject property set by our XDND workarounds in xworkaround.cpp.
     xcb_window_t dndSource = xcb_window_t(targetWidget->property("xdnd::lastDragSource").toUInt());
-    xcb_timestamp_t dropTimestamp = (xcb_timestamp_t)targetWidget->property("xdnd::lastDropTime").toUInt();
+    //xcb_timestamp_t dropTimestamp = (xcb_timestamp_t)targetWidget->property("xdnd::lastDropTime").toUInt();
     // qDebug() << "XDS: source window" << dndSource << dropTimestamp;
     if(dndSource != 0) {
-      xcb_connection_t* conn = QX11Info::connection();
       xcb_atom_t XdndDirectSaveAtom = XdndWorkaround::internAtom("XdndDirectSave0", 15);
       xcb_atom_t textAtom = XdndWorkaround::internAtom("text/plain", 10);
 
@@ -923,6 +923,7 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
         }
       }
       break;
+    default: break;
     }
   }
   return QObject::eventFilter(watched, event);

--- a/src/mountoperation.cpp
+++ b/src/mountoperation.cpp
@@ -31,10 +31,10 @@ namespace Fm {
 
 MountOperation::MountOperation(bool interactive, QWidget* parent):
   QObject(parent),
-  interactive_(interactive),
-  running(false),
   op(g_mount_operation_new()),
   cancellable_(g_cancellable_new()),
+  running(false),
+  interactive_(interactive),
   eventLoop(NULL),
   autoDestroy_(true) {
 

--- a/src/mountoperationpassworddialog.cpp
+++ b/src/mountoperationpassworddialog.cpp
@@ -27,11 +27,11 @@ namespace Fm {
 MountOperationPasswordDialog::MountOperationPasswordDialog(MountOperation* op, GAskPasswordFlags flags):
   QDialog(),
   mountOperation(op),
-  canAnonymous(flags & G_ASK_PASSWORD_ANONYMOUS_SUPPORTED ? true : false),
-  canSavePassword(flags & G_ASK_PASSWORD_SAVING_SUPPORTED ? true : false),
-  needUserName(flags & G_ASK_PASSWORD_NEED_USERNAME ? true : false),
   needPassword(flags & G_ASK_PASSWORD_NEED_PASSWORD ? true : false),
-  needDomain(flags & G_ASK_PASSWORD_NEED_DOMAIN ? true : false) {
+  needUserName(flags & G_ASK_PASSWORD_NEED_USERNAME ? true : false),
+  needDomain(flags & G_ASK_PASSWORD_NEED_DOMAIN ? true : false),
+  canSavePassword(flags & G_ASK_PASSWORD_SAVING_SUPPORTED ? true : false),
+  canAnonymous(flags & G_ASK_PASSWORD_ANONYMOUS_SUPPORTED ? true : false) {
 
   ui = new Ui::MountOperationPasswordDialog();
   ui->setupUi(this);

--- a/src/pathedit.cpp
+++ b/src/pathedit.cpp
@@ -69,9 +69,9 @@ void PathEditJob::runJob() {
 
 PathEdit::PathEdit(QWidget* parent):
   QLineEdit(parent),
-  cancellable_(NULL),
+  completer_(new QCompleter()),
   model_(new QStringListModel()),
-  completer_(new QCompleter()) {
+  cancellable_(NULL) {
   setCompleter(completer_);
   completer_->setModel(model_);
   connect(this, &PathEdit::textChanged, this, &PathEdit::onTextChanged);

--- a/src/placesmodelitem.cpp
+++ b/src/placesmodelitem.cpp
@@ -27,15 +27,15 @@ namespace Fm {
 PlacesModelItem::PlacesModelItem():
   QStandardItem(),
   path_(NULL),
-  icon_(NULL),
-  fileInfo_(NULL) {
+  fileInfo_(NULL),
+  icon_(NULL) {
 }
 
 PlacesModelItem::PlacesModelItem(const char* iconName, QString title, FmPath* path):
   QStandardItem(title),
   path_(path ? fm_path_ref(path) : NULL),
-  icon_(fm_icon_from_name(iconName)),
-  fileInfo_(NULL) {
+  fileInfo_(NULL),
+  icon_(fm_icon_from_name(iconName)) {
   if(icon_)
     QStandardItem::setIcon(IconTheme::icon(icon_));
   setEditable(false);
@@ -44,8 +44,8 @@ PlacesModelItem::PlacesModelItem(const char* iconName, QString title, FmPath* pa
 PlacesModelItem::PlacesModelItem(FmIcon* icon, QString title, FmPath* path):
   QStandardItem(title),
   path_(path ? fm_path_ref(path) : NULL),
-  icon_(icon ? fm_icon_ref(icon) : NULL),
-  fileInfo_(NULL) {
+  fileInfo_(NULL),
+  icon_(icon ? fm_icon_ref(icon) : NULL) {
   if(icon_)
     QStandardItem::setIcon(IconTheme::icon(icon));
   setEditable(false);
@@ -53,9 +53,9 @@ PlacesModelItem::PlacesModelItem(FmIcon* icon, QString title, FmPath* path):
 
 PlacesModelItem::PlacesModelItem(QIcon icon, QString title, FmPath* path):
   QStandardItem(icon, title),
-  icon_(NULL),
   path_(path ? fm_path_ref(path) : NULL),
-  fileInfo_(NULL) {
+  fileInfo_(NULL),
+  icon_(NULL) {
   setEditable(false);
 }
 

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -26,10 +26,10 @@ namespace Fm {
 
 ProxyFolderModel::ProxyFolderModel(QObject * parent):
   QSortFilterProxyModel(parent),
-  thumbnailSize_(0),
   showHidden_(false),
+  folderFirst_(true),
   showThumbnails_(false),
-  folderFirst_(true) {
+  thumbnailSize_(0) {
   setDynamicSortFilter(true);
   setSortCaseSensitivity(Qt::CaseInsensitive);
 }

--- a/src/sidepane.cpp
+++ b/src/sidepane.cpp
@@ -32,12 +32,12 @@ namespace Fm {
 
 SidePane::SidePane(QWidget* parent):
   QWidget(parent),
-  showHidden_(false),
-  mode_(ModeNone),
+  currentPath_(NULL),
   view_(NULL),
   combo_(NULL),
-  currentPath_(NULL),
-  iconSize_(24, 24) {
+  iconSize_(24, 24),
+  mode_(ModeNone),
+  showHidden_(false) {
 
   verticalLayout = new QVBoxLayout(this);
   verticalLayout->setContentsMargins(0, 0, 0, 0);

--- a/src/thumbnailloader.cpp
+++ b/src/thumbnailloader.cpp
@@ -98,7 +98,7 @@ ThumbnailLoader::ThumbnailLoader() {
     getImageText,
     setImageText
   };
-  gboolean success = fm_thumbnail_loader_set_backend(&qt_backend);
+  fm_thumbnail_loader_set_backend(&qt_backend);
 }
 
 ThumbnailLoader::~ThumbnailLoader() {
@@ -117,7 +117,7 @@ GObject* ThumbnailLoader::readImageFromStream(GInputStream* stream, guint64 len,
   // FIXME: should we set a limit here? Otherwise if len is too large, we can run out of memory.
   QScopedArrayPointer<unsigned char> buffer(new unsigned char[len]); // allocate enough buffer
   unsigned char* pbuffer = buffer.data();
-  int totalReadSize = 0;
+  unsigned int totalReadSize = 0;
   while(!g_cancellable_is_cancelled(cancellable) && totalReadSize < len) {
     int bytesToRead = totalReadSize + 4096 > len ? len - totalReadSize : 4096;
     gssize readSize = g_input_stream_read(stream, pbuffer, bytesToRead, cancellable, NULL);

--- a/src/xdndworkaround.cpp
+++ b/src/xdndworkaround.cpp
@@ -84,7 +84,6 @@ XdndWorkaround::~XdndWorkaround() {
 bool XdndWorkaround::nativeEventFilter(const QByteArray & eventType, void * message, long * result) {
   if(Q_LIKELY(eventType == "xcb_generic_event_t")) {
     xcb_generic_event_t* event = static_cast<xcb_generic_event_t *>(message);
-    uint8_t response_type = event->response_type & uint8_t(~0x80);
     switch(event->response_type & ~0x80) {
     case XCB_CLIENT_MESSAGE:
       return clientMessage(reinterpret_cast<xcb_client_message_event_t*>(event));
@@ -163,12 +162,11 @@ QByteArray XdndWorkaround::windowProperty(xcb_window_t window, xcb_atom_t propAt
 // static
 void XdndWorkaround::setWindowProperty(xcb_window_t window, xcb_atom_t propAtom, xcb_atom_t typeAtom, void* data, int len, int format) {
   xcb_connection_t* conn = QX11Info::connection();
-  xcb_void_cookie_t cookie = xcb_change_property(conn, XCB_PROP_MODE_REPLACE, window, propAtom, typeAtom, format, len, data);
+  xcb_change_property(conn, XCB_PROP_MODE_REPLACE, window, propAtom, typeAtom, format, len, data);
 }
 
 
 bool XdndWorkaround::clientMessage(xcb_client_message_event_t* event) {
-  xcb_connection_t* conn = QX11Info::connection();
   QByteArray event_type = atomName(event->type);
   // qDebug() << "client message:" << event_type;
 


### PR DESCRIPTION
All new warnings and some old ones are silenced. However, I didn't try to silence some *old* warnings about `filepropsdialog.cpp` because I saw odd assignments in it.