### PR TITLE
Emblem For (Encrypted) Volume Icons

### DIFF
--- a/src/icontheme.h
+++ b/src/icontheme.h
@@ -49,6 +49,7 @@ public:
   static IconTheme* instance();
   static QIcon icon(FmIcon* fmicon);
   static QIcon icon(GIcon* gicon);
+  static QIcon getEmblem(GIcon* gicon);
 
   static void checkChanged(); // check if current icon theme name is changed
 Q_SIGNALS:

--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -30,12 +30,13 @@
 
 namespace Fm {
 
-PlacesModel::PlacesModel(QObject* parent):
+PlacesModel::PlacesModel(QObject* parent, QSize iconSize):
   QStandardItemModel(parent),
   showApplications_(true),
   showDesktop_(true),
   ejectIcon_(QIcon::fromTheme("media-eject")) {
 
+  iconSize_ = iconSize;
   setColumnCount(2);
 
   placesRoot = new QStandardItem(tr("Places"));
@@ -131,7 +132,7 @@ PlacesModel::PlacesModel(QObject* parent):
             continue;
           }
           else {
-            PlacesModelItem* item = new PlacesModelMountItem(mount);
+            PlacesModelItem* item = new PlacesModelMountItem(mount, iconSize_);
             devicesRoot->appendRow(item);
           }
         }
@@ -370,7 +371,7 @@ void PlacesModel::onMountAdded(GVolumeMonitor* monitor, GMount* mount, PlacesMod
     /* for some unknown reasons, sometimes we get repeated mount-added
      * signals and added a device more than one. So, make a sanity check here. */
     if(!item) {
-      item = new PlacesModelMountItem(mount);
+      item = new PlacesModelMountItem(mount, pThis->iconSize_);
       QStandardItem* eject_btn = new QStandardItem(pThis->ejectIcon_, QString());
       pThis->devicesRoot->appendRow(QList<QStandardItem*>() << item << eject_btn);
     }
@@ -442,7 +443,7 @@ void PlacesModel::onVolumeAdded(GVolumeMonitor* monitor, GVolume* volume, Places
   // signals and added a device more than one. So, make a sanity check here.
   PlacesModelVolumeItem* volumeItem = pThis->itemFromVolume(volume);
   if(!volumeItem) {
-    volumeItem = new PlacesModelVolumeItem(volume);
+    volumeItem = new PlacesModelVolumeItem(volume, pThis->iconSize_);
     QStandardItem* ejectBtn = new QStandardItem();
     if(volumeItem->isMounted())
       ejectBtn->setIcon(pThis->ejectIcon_);
@@ -483,11 +484,13 @@ void PlacesModel::updateIcons() {
   int n = placesRoot->rowCount();
   for(row = 0; row < n; ++row) {
     item = static_cast<PlacesModelItem*>(placesRoot->child(row));
+    item->setIconSize(iconSize_);
     item->updateIcon();
   }
   n = devicesRoot->rowCount();
   for(row = 0; row < n; ++row) {
     item = static_cast<PlacesModelItem*>(devicesRoot->child(row));
+    item->setIconSize(iconSize_);
     item->updateIcon();
   }
 }

--- a/src/placesmodel.h
+++ b/src/placesmodel.h
@@ -56,7 +56,7 @@ public:
   };
 
 public:
-  explicit PlacesModel(QObject* parent = 0);
+  explicit PlacesModel(QObject* parent = 0, QSize iconSize = QSize());
   virtual ~PlacesModel();
 
   bool showTrash() {
@@ -73,6 +73,13 @@ public:
     return showDesktop_;
   }
   void setShowDesktop(bool show);
+
+  void setIconSize(QSize size) {
+    if (iconSize_ != size) {
+      iconSize_ = size;
+      updateIcons(); // for emblems
+    }
+  }
 
 public Q_SLOTS:
   void updateIcons();
@@ -126,6 +133,7 @@ private:
   PlacesModelItem* applicationsItem;
   QIcon ejectIcon_;
   QList<GMount*> shadowedMounts_;
+  QSize iconSize_; // for setting the size hint of PlacesModelItem
 };
 
 }

--- a/src/placesmodelitem.cpp
+++ b/src/placesmodelitem.cpp
@@ -21,21 +21,25 @@
 #include "placesmodelitem.h"
 #include "icontheme.h"
 #include <gio/gio.h>
+#include <QPainter>
 
 namespace Fm {
 
-PlacesModelItem::PlacesModelItem():
+PlacesModelItem::PlacesModelItem(QSize size):
   QStandardItem(),
   path_(NULL),
   fileInfo_(NULL),
-  icon_(NULL) {
+  icon_(NULL),
+  gicon_(NULL) {
+  iconSize_ = size;
 }
 
 PlacesModelItem::PlacesModelItem(const char* iconName, QString title, FmPath* path):
   QStandardItem(title),
   path_(path ? fm_path_ref(path) : NULL),
   fileInfo_(NULL),
-  icon_(fm_icon_from_name(iconName)) {
+  icon_(fm_icon_from_name(iconName)),
+  gicon_(NULL) {
   if(icon_)
     QStandardItem::setIcon(IconTheme::icon(icon_));
   setEditable(false);
@@ -45,7 +49,8 @@ PlacesModelItem::PlacesModelItem(FmIcon* icon, QString title, FmPath* path):
   QStandardItem(title),
   path_(path ? fm_path_ref(path) : NULL),
   fileInfo_(NULL),
-  icon_(icon ? fm_icon_ref(icon) : NULL) {
+  icon_(icon ? fm_icon_ref(icon) : NULL),
+  gicon_(NULL) {
   if(icon_)
     QStandardItem::setIcon(IconTheme::icon(icon));
   setEditable(false);
@@ -55,7 +60,8 @@ PlacesModelItem::PlacesModelItem(QIcon icon, QString title, FmPath* path):
   QStandardItem(icon, title),
   path_(path ? fm_path_ref(path) : NULL),
   fileInfo_(NULL),
-  icon_(NULL) {
+  icon_(NULL),
+  gicon_(NULL) {
   setEditable(false);
 }
 
@@ -66,6 +72,8 @@ PlacesModelItem::~PlacesModelItem() {
     g_object_unref(fileInfo_);
   if(icon_)
     fm_icon_unref(icon_);
+  if(gicon_)
+    g_object_unref(gicon_);
 }
 
 void PlacesModelItem::setPath(FmPath* path) {
@@ -80,6 +88,10 @@ void PlacesModelItem::setIcon(FmIcon* icon) {
   if(icon) {
     icon_ = fm_icon_ref(icon);
     QStandardItem::setIcon(IconTheme::icon(icon_));
+    if(gicon_) { // either FmIcon or emblemed GIcon
+      g_object_unref(gicon_);
+      gicon_ = NULL;
+    }
   }
   else {
     icon_ = NULL;
@@ -88,6 +100,27 @@ void PlacesModelItem::setIcon(FmIcon* icon) {
 }
 
 void PlacesModelItem::setIcon(GIcon* gicon) {
+  if(!iconSize_.isEmpty() && gicon && G_IS_EMBLEMED_ICON(gicon)) {
+    QIcon emblem = IconTheme::getEmblem(gicon);
+    if (!emblem.isNull()) {
+      if(gicon_)
+        g_object_unref(gicon_);
+      gicon_ = (GIcon*)g_object_ref(gicon);
+      QIcon icon = IconTheme::icon(gicon);
+      QPixmap pix = icon.pixmap(iconSize_);
+      QPainter p(&pix);
+      QSize emblemSize = pix.size() / 2;
+      QPoint emblemPos = pix.rect().bottomRight() - QPoint(emblemSize.width(), emblemSize.height());
+      p.drawPixmap(emblemPos, emblem.pixmap(emblemSize));
+      icon = QIcon(pix);
+      QStandardItem::setIcon(icon);
+      if(icon_) { // either FmIcon or emblemed GIcon
+        fm_icon_unref(icon_);
+        icon_ = NULL;
+      }
+      return;
+    }
+  }
   FmIcon* icon = gicon ? fm_icon_from_gicon(gicon) : NULL;
   setIcon(icon);
   fm_icon_unref(icon);
@@ -96,6 +129,8 @@ void PlacesModelItem::setIcon(GIcon* gicon) {
 void PlacesModelItem::updateIcon() {
   if(icon_)
     QStandardItem::setIcon(IconTheme::icon(icon_));
+  else if(gicon_)
+    setIcon(gicon_);
 }
 
 QVariant PlacesModelItem::data(int role) const {
@@ -121,8 +156,8 @@ PlacesModelBookmarkItem::PlacesModelBookmarkItem(FmBookmarkItem* bm_item):
   setEditable(true);
 }
 
-PlacesModelVolumeItem::PlacesModelVolumeItem(GVolume* volume):
-  PlacesModelItem(),
+PlacesModelVolumeItem::PlacesModelVolumeItem(GVolume* volume, QSize size):
+  PlacesModelItem(size),
   volume_(reinterpret_cast<GVolume*>(g_object_ref(volume))) {
   update();
   setEditable(false);
@@ -163,8 +198,8 @@ bool PlacesModelVolumeItem::isMounted() {
 }
 
 
-PlacesModelMountItem::PlacesModelMountItem(GMount* mount):
-  PlacesModelItem(),
+PlacesModelMountItem::PlacesModelMountItem(GMount* mount, QSize size):
+  PlacesModelItem(size),
   mount_(reinterpret_cast<GMount*>(mount)) {
   update();
   setEditable(false);

--- a/src/placesmodelitem.h
+++ b/src/placesmodelitem.h
@@ -41,7 +41,7 @@ public:
   };
 
 public:
-  PlacesModelItem();
+  PlacesModelItem(QSize size = QSize());
   PlacesModelItem(QIcon icon, QString title, FmPath* path = NULL);
   PlacesModelItem(const char* iconName, QString title, FmPath* path = NULL);
   PlacesModelItem(FmIcon* icon, QString title, FmPath* path = NULL);
@@ -70,15 +70,21 @@ public:
     return Places;
   }
 
+  void setIconSize(QSize size) {
+    iconSize_ = size;
+  }
+
 private:
   FmPath* path_;
   FmFileInfo* fileInfo_;
   FmIcon* icon_;
+  GIcon* gicon_;
+  QSize iconSize_;
 };
 
 class LIBFM_QT_API PlacesModelVolumeItem : public PlacesModelItem {
 public:
-  PlacesModelVolumeItem(GVolume* volume);
+  PlacesModelVolumeItem(GVolume* volume, QSize size = QSize());
   bool isMounted();
   bool canEject() {
     return g_volume_can_eject(volume_);
@@ -96,7 +102,7 @@ private:
 
 class LIBFM_QT_API PlacesModelMountItem : public PlacesModelItem {
 public:
-  PlacesModelMountItem(GMount* mount);
+  PlacesModelMountItem(GMount* mount, QSize size = QSize());
   virtual int type() const {
     return Mount;
   }

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -44,7 +44,7 @@ PlacesView::PlacesView(QWidget* parent):
   setIconSize(QSize(24, 24));
 
   // FIXME: we may share this model amont all views
-  model_ = new PlacesModel(this);
+  model_ = new PlacesModel(this, iconSize());
   setModel(model_);
 
   QHeaderView* headerView = header();
@@ -120,6 +120,7 @@ void PlacesView::onPressed(const QModelIndex& index) {
 
 void PlacesView::onIconSizeChanged(const QSize& size) {
   setColumnWidth(1, size.width() + 5);
+  model_->setIconSize(size);
 }
 
 void PlacesView::onEjectButtonClicked(PlacesModelItem* item) {


### PR DESCRIPTION
GLib may give emblems to volume icons but drawing emblems was not possible because there is no size hint in PlacesModelItem (see https://github.com/lxde/libfm-qt/pull/41#issuecomment-250140781). This PR simply gets the required icon size from PlacesView (through PlacesModel) and draws the GIcon emblem.

In my opinion, the hard task of hacking XdgIcon is an overkill for such a simple job -- we don't need emblems in other places (for now).