### PR TITLE
Scroll Pathbar with Mouse Wheel

### DIFF
--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -239,8 +239,10 @@ void PathBar::closeEditor() {
     return;
   layout()->replaceWidget(tempPathEdit_, scrollArea_, Qt::FindDirectChildrenOnly);
   scrollArea_->show();
+  if(buttonsLayout_->sizeHint().width() > width()) {
     leftArrow_->setVisible(true);
     rightArrow_->setVisible(true);
+  }
 
   tempPathEdit_->deleteLater();
   tempPathEdit_ = nullptr;

--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -135,10 +135,12 @@ void PathBar::updateScrollButtonVisibility() {
   }
   leftArrow_->setVisible(showScrollers);
   rightArrow_->setVisible(showScrollers);
-  QScrollBar* sb = scrollArea_->horizontalScrollBar();
-  int value = sb->value();
-  leftArrow_->setEnabled(value != sb->minimum());
-  rightArrow_->setEnabled(value != sb->maximum());
+  if(showScrollers) {
+    QScrollBar* sb = scrollArea_->horizontalScrollBar();
+    int value = sb->value();
+    leftArrow_->setEnabled(value != sb->minimum());
+    rightArrow_->setEnabled(value != sb->maximum());
+  }
 }
 
 void PathBar::onButtonToggled(bool checked) {
@@ -264,9 +266,11 @@ void PathBar::onReturnPressed() {
 }
 
 void PathBar::setArrowEnabledState(int value) {
-  QScrollBar* sb = scrollArea_->horizontalScrollBar();
-  leftArrow_->setEnabled(value != sb->minimum());
-  rightArrow_->setEnabled(value != sb->maximum());
+  if(buttonsLayout_->sizeHint().width() > width()) {
+    QScrollBar* sb = scrollArea_->horizontalScrollBar();
+    leftArrow_->setEnabled(value != sb->minimum());
+    rightArrow_->setEnabled(value != sb->maximum());
+  }
 }
 
 

--- a/src/pathbar.h
+++ b/src/pathbar.h
@@ -57,9 +57,11 @@ private Q_SLOTS:
   void onButtonToggled(bool checked);
   void onScrollButtonClicked();
   void onReturnPressed();
+  void setArrowEnabledState(int value);
 
 protected:
   void resizeEvent(QResizeEvent* event);
+  void wheelEvent (QWheelEvent* event);
   void mousePressEvent(QMouseEvent *event);
   void contextMenuEvent(QContextMenuEvent *event);
 


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/419.

Also arrow buttons are fixed for RTL and their enabled state is set correctly. In addition, they are made hidden on editing pathbar.

The one-step scrolling by clicking on the arrow buttons is kept because wheel scrolling is possible now.