### PR TITLE
Path Button Middle Click

### DIFF
--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -125,6 +125,12 @@ void PathBar::onButtonToggled(bool checked) {
   }
 }
 
+void PathBar::onButtonMiddleClicked() {
+  PathButton* btn = static_cast<PathButton*>(sender());
+  scrollArea_->ensureWidgetVisible(btn, 0);
+  Q_EMIT middleClickChdir(btn->pathElement().dataPtr());
+}
+
 void PathBar::onScrollButtonClicked() {
   QToolButton* btn = static_cast<QToolButton*>(sender());
   QAbstractSlider::SliderAction action;
@@ -180,6 +186,7 @@ void PathBar::setPath(Path path) {
     PathButton* btn = new PathButton(pathElement, buttonsWidget_);
     btn->show();
     connect(btn, &QPushButton::toggled, this, &PathBar::onButtonToggled);
+    connect(btn, &PathButton::middleClicked, this, &PathBar::onButtonMiddleClicked);
     pathElement = pathElement.getParent();
     buttonsLayout_->insertWidget(0, btn);
   }

--- a/src/pathbar.h
+++ b/src/pathbar.h
@@ -46,6 +46,7 @@ public:
 
 Q_SIGNALS:
   void chdir(FmPath* path);
+  void middleClickChdir(FmPath* path);
   void editingFinished();
 
 public Q_SLOTS:
@@ -55,6 +56,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
   void onButtonToggled(bool checked);
+  void onButtonMiddleClicked();
   void onScrollButtonClicked();
   void onReturnPressed();
 

--- a/src/pathbar_p.h
+++ b/src/pathbar_p.h
@@ -21,6 +21,7 @@
 #define FM_PATHBAR_P_H
 
 #include <QToolButton>
+#include <QMouseEvent>
 #include "path.h"
 
 namespace Fm {
@@ -53,6 +54,16 @@ public:
 
   void setPathElement(Path pathElement) {
     pathElement_ = pathElement;
+  }
+
+Q_SIGNALS:
+  void middleClicked();
+
+private Q_SLOTS:
+  void mousePressEvent(QMouseEvent *e) {
+    QToolButton::mousePressEvent(e);
+    if(e->button() == Qt::MidButton)
+      Q_EMIT middleClicked();
   }
 
 private:


### PR DESCRIPTION
Added a signal on middle clicking a path button. To be used in pcmanfm-qt for opening the corresponding folder in a new tab.