### PR TITLE
Fix Pathbar Paint on Menu Pop-Up

### DIFF
--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -246,6 +246,9 @@ void PathBar::openEditor() {
 void PathBar::closeEditor() {
   if(tempPathEdit_ == nullptr)
     return;
+  // If a menu has popped up synchronously (with QMenu::exec), the path buttons may be drawn
+  // but the path-edit may not disappear until the menu is closed. So, we hide it here.
+  tempPathEdit_->setVisible(false);
   layout()->replaceWidget(tempPathEdit_, scrollArea_, Qt::FindDirectChildrenOnly);
   scrollArea_->show();
   if(buttonsLayout_->sizeHint().width() > width()) {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/422 by hiding path-edit before deleting it.