### PR TITLE
Use QByteArray::constData() where we can

### DIFF
--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -439,7 +439,7 @@ void FilePropsDialog::accept() {
       FmPath* path = fm_file_info_get_path(fileInfo);
       GFile* gf = fm_path_to_gfile(path);
       GFile* parent_gf = g_file_get_parent(gf);
-      GFile* dest = g_file_get_child(G_FILE(parent_gf), new_name.toLocal8Bit().data());
+      GFile* dest = g_file_get_child(G_FILE(parent_gf), new_name.toLocal8Bit().constData());
       g_object_unref(parent_gf);
       GError* err = NULL;
       if(!g_file_move(gf, dest,

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -533,7 +533,7 @@ QImage FolderModel::thumbnailFromIndex(const QModelIndex& index, int size) {
   FolderModelItem* item = itemFromIndex(index);
   if(item) {
     FolderModelItem::Thumbnail* thumbnail = item->findThumbnail(size);
-    // qDebug("FolderModel::thumbnailFromIndex: %d, %s", thumbnail->status, item->displayName.toUtf8().data());
+    // qDebug("FolderModel::thumbnailFromIndex: %d, %s", thumbnail->status, item->displayName.toUtf8().constData());
     switch(thumbnail->status) {
       case FolderModelItem::ThumbnailNotChecked: {
         // load the thumbnail

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -234,7 +234,7 @@ QVariant ProxyFolderModel::data(const QModelIndex& index, int role) const {
 void ProxyFolderModel::onThumbnailLoaded(const QModelIndex& srcIndex, int size) {
   // FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
   // FolderModelItem* item = srcModel->itemFromIndex(srcIndex);
-  // qDebug("ProxyFolderModel::onThumbnailLoaded: %d, %s", size, item->displayName.toUtf8().data());
+  // qDebug("ProxyFolderModel::onThumbnailLoaded: %d, %s", size, item->displayName.toUtf8().constData());
 
   if(size == thumbnailSize_) { // if a thumbnail of the size we want is loaded
     QModelIndex index = mapFromSource(srcIndex);

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -136,7 +136,7 @@ void renameFile(FmFileInfo *file, QWidget *parent) {
 
   GFile* gf = fm_path_to_gfile(path);
   GFile* parent_gf = g_file_get_parent(gf);
-  GFile* dest = g_file_get_child(G_FILE(parent_gf), new_name.toLocal8Bit().data());
+  GFile* dest = g_file_get_child(G_FILE(parent_gf), new_name.toLocal8Bit().constData());
   g_object_unref(parent_gf);
 
   GError* err = NULL;
@@ -193,7 +193,7 @@ _retry:
     return;
 
   GFile* parent_gf = fm_path_to_gfile(parentDir);
-  GFile* dest_gf = g_file_get_child(G_FILE(parent_gf), new_name.toLocal8Bit().data());
+  GFile* dest_gf = g_file_get_child(G_FILE(parent_gf), new_name.toLocal8Bit().constData());
   g_object_unref(parent_gf);
 
   GError* err = NULL;


### PR DESCRIPTION
Faster than data() because it never causes a deep copy to occur.