### PR TITLE
Use const iterators

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -727,7 +727,7 @@ Fm::PathList FolderView::selectedFilePaths() const {
     if(!selIndexes.isEmpty()) {
       PathList paths;
       QModelIndexList::const_iterator it;
-      for(it = selIndexes.begin(); it != selIndexes.end(); ++it) {
+      for(it = selIndexes.constBegin(); it != selIndexes.constEnd(); ++it) {
         FmFileInfo* file = model_->fileInfoFromIndex(*it);
         paths.pushTail(fm_file_info_get_path(file));
       }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -40,7 +40,7 @@ FmPathList* pathListFromQUrls(QList<QUrl> urls) {
   QList<QUrl>::const_iterator it;
   FmPathList* pathList = fm_path_list_new();
 
-  for(it = urls.begin(); it != urls.end(); ++it) {
+  for(it = urls.constBegin(); it != urls.constEnd(); ++it) {
     QUrl url = *it;
     FmPath* path = fm_path_new_for_uri(url.toString().toUtf8());
     fm_path_list_push_tail(pathList, path);


### PR DESCRIPTION
Avoid assignment of a non-const pointer to a const pointer and the
consequent container detach.