### PR TITLE
Inline Renaming

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -38,14 +38,16 @@ namespace Fm {
 
 FileMenu::FileMenu(FmFileInfoList* files, FmFileInfo* info, FmPath* cwd, QWidget* parent):
   QMenu(parent),
-  fileLauncher_(NULL) {
+  fileLauncher_(NULL),
+  view_ (NULL) {
   createMenu(files, info, cwd);
 }
 
 FileMenu::FileMenu(FmFileInfoList* files, FmFileInfo* info, FmPath* cwd, const QString& title, QWidget* parent):
   QMenu(title, parent),
   unTrashAction_(NULL),
-  fileLauncher_(NULL) {
+  fileLauncher_(NULL),
+  view_ (NULL) {
   createMenu(files, info, cwd);
 }
 
@@ -362,9 +364,16 @@ void FileMenu::onPasteTriggered() {
 }
 
 void FileMenu::onRenameTriggered() {
-  for(GList* l = fm_file_info_list_peek_head_link(files_); l; l = l->next) {
-    FmFileInfo* info = FM_FILE_INFO(l->data);
-    Fm::renameFile(info, NULL);
+  if (view_) {
+    // if there is a view, just edit the current index
+    if (view_->currentIndex().isValid())
+      view_->edit(view_->currentIndex());
+  }
+  else {
+    for(GList* l = fm_file_info_list_peek_head_link(files_); l; l = l->next) {
+      FmFileInfo* info = FM_FILE_INFO(l->data);
+      Fm::renameFile(info, NULL);
+    }
   }
 }
 

--- a/src/filemenu.h
+++ b/src/filemenu.h
@@ -23,6 +23,7 @@
 
 #include "libfmqtglobals.h"
 #include <QMenu>
+#include <QAbstractItemView>
 #include <qabstractitemmodel.h>
 #include <libfm/fm.h>
 
@@ -156,6 +157,10 @@ public:
     confirmTrash_ = value;
   }
 
+  void setView(QAbstractItemView* view) {
+    view_ = view;
+  }
+
 protected:
   void createMenu(FmFileInfoList* files, FmFileInfo* info, FmPath* cwd);
 #ifdef CUSTOM_ACTIONS
@@ -209,6 +214,7 @@ private:
   QAction* renameAction_;
   QAction* separator3_;
   QAction* propertiesAction_;
+  QAbstractItemView* view_;
 
   FileLauncher* fileLauncher_;
 };

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -278,7 +278,9 @@ void FolderItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index
     return;
   const QString currentName = index.data(Qt::EditRole).toString();
   textEdit->setPlainText(currentName);
+  textEdit->setUndoRedoEnabled(false);
   textEdit->setAlignment(Qt::AlignCenter);
+  textEdit->setUndoRedoEnabled(true);
   // select text appropriately
   QTextCursor cur = textEdit->textCursor();
   int end;

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -28,6 +28,7 @@
 #include <QTextLayout>
 #include <QTextOption>
 #include <QTextLine>
+#include <QTextEdit>
 #include <QDebug>
 
 namespace Fm {
@@ -248,6 +249,73 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItem& opt, 
       style->drawPrimitive(QStyle::PE_FrameFocusRect, &o, painter, widget);
     }
   }
+}
+
+/*
+ * The following methods are for inline renaming.
+*/
+
+QWidget* FolderItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const {
+  // we use QTextEdit instead of QPlainTextEdit because
+  // the latter always shows an empty space at the bottom
+  QTextEdit *textEdit = new QTextEdit(parent);
+  textEdit->ensureCursorVisible();
+  textEdit->setFocusPolicy(Qt::StrongFocus);
+  textEdit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  textEdit->setContentsMargins(0, 0, 0, 0);
+  return textEdit;
+}
+
+void FolderItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const {
+  if (!index.isValid())
+    return;
+  QTextEdit *textEdit = qobject_cast<QTextEdit*>(editor);
+  if (!textEdit)
+    return;
+  const QString currentName = index.data(Qt::EditRole).toString();
+  textEdit->setPlainText(currentName);
+  textEdit->setAlignment(Qt::AlignCenter);
+  // select text appropriately
+  QTextCursor cur = textEdit->textCursor();
+  int end;
+  if (index.data(Fm::FolderModel::FileIsDirRole).toBool() || !currentName.contains("."))
+    end = currentName.size();
+  else
+    end = currentName.lastIndexOf(".");
+  cur.setPosition(end, QTextCursor::KeepAnchor);
+  textEdit->setTextCursor(cur);
+}
+
+bool FolderItemDelegate::eventFilter(QObject *object, QEvent *event) {
+  QWidget *editor = qobject_cast<QWidget*>(object);
+  if (editor && event->type() == QEvent::KeyPress) {
+    int k = static_cast<QKeyEvent *>(event)->key();
+    if (k == Qt::Key_Return || k == Qt::Key_Enter) {
+      Q_EMIT QAbstractItemDelegate::commitData(editor);
+      Q_EMIT QAbstractItemDelegate::closeEditor(editor, QAbstractItemDelegate::NoHint);
+      return true;
+    }
+  }
+  return QStyledItemDelegate::eventFilter(object, event);
+}
+
+void FolderItemDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const {
+  if (gridSize_ != QSize()
+      && (option.decorationPosition == QStyleOptionViewItem::Top
+          || option.decorationPosition == QStyleOptionViewItem::Bottom)) {
+    // give all of the available space to the editor
+    QStyleOptionViewItem opt = option;
+    initStyleOption(&opt, index);
+    opt.decorationAlignment = Qt::AlignHCenter|Qt::AlignTop;
+    opt.displayAlignment = Qt::AlignTop|Qt::AlignHCenter;
+    QRect textRect(opt.rect.x() - (gridSize_.width() - opt.rect.width()) / 2,
+                   opt.rect.y() + option.decorationSize.height(),
+                   gridSize_.width(),
+                   gridSize_.height() - option.decorationSize.height());
+    editor->setGeometry(textRect);
+  }
+  else
+    QStyledItemDelegate::updateEditorGeometry(editor, option, index);
 }
 
 

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -262,6 +262,7 @@ QWidget* FolderItemDelegate::createEditor(QWidget *parent, const QStyleOptionVie
   // the latter always shows an empty space at the bottom
   QTextEdit *textEdit = new QTextEdit(parent);
   hasEditor_ = true;
+  textEdit->setAcceptRichText(false);
   textEdit->ensureCursorVisible();
   textEdit->setFocusPolicy(Qt::StrongFocus);
   textEdit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -38,7 +38,9 @@ FolderItemDelegate::FolderItemDelegate(QAbstractItemView* view, QObject* parent)
   view_(view),
   symlinkIcon_(QIcon::fromTheme("emblem-symbolic-link")),
   fileInfoRole_(Fm::FolderModel::FileInfoRole),
-  fmIconRole_(-1) {
+  fmIconRole_(-1),
+  hasEditor_(false) {
+  connect(this,  &QAbstractItemDelegate::closeEditor, [=]{hasEditor_ = false;});
 }
 
 FolderItemDelegate::~FolderItemDelegate() {
@@ -259,6 +261,7 @@ QWidget* FolderItemDelegate::createEditor(QWidget *parent, const QStyleOptionVie
   // we use QTextEdit instead of QPlainTextEdit because
   // the latter always shows an empty space at the bottom
   QTextEdit *textEdit = new QTextEdit(parent);
+  hasEditor_ = true;
   textEdit->ensureCursorVisible();
   textEdit->setFocusPolicy(Qt::StrongFocus);
   textEdit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -57,6 +57,10 @@ public:
     fmIconRole_ = role;
   }
 
+  bool hasEditor() const {
+    return hasEditor_;
+  }
+
   virtual QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const;
   virtual void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
   virtual QWidget* createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
@@ -74,6 +78,7 @@ private:
   QSize gridSize_;
   int fileInfoRole_;
   int fmIconRole_;
+  mutable bool hasEditor_;
 };
 
 }

--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -59,6 +59,10 @@ public:
 
   virtual QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const;
   virtual void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+  virtual QWidget* createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+  virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
+  virtual bool eventFilter(QObject *object, QEvent *event);
+  virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
 private:
   void drawText(QPainter* painter, QStyleOptionViewItem& opt, QRectF& textRect) const;

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -233,8 +233,17 @@ QVariant FolderModel::data(const QModelIndex & index, int role/* = Qt::DisplayRo
       }
       break;
     }
+    case Qt::EditRole: {
+      if(index.column() == 0) {
+        // inline renaming (see FolderItemDelegate::setEditorData())
+        return QVariant(item->displayName);
+      }
+      break;
+    }
     case FileInfoRole:
       return qVariantFromValue((void*)info);
+    case FileIsDirRole:
+      return QVariant(fm_file_info_is_dir(info));
   }
   return QVariant();
 }
@@ -283,7 +292,8 @@ Qt::ItemFlags FolderModel::flags(const QModelIndex& index) const {
   if(index.isValid()) {
     flags = Qt::ItemIsEnabled|Qt::ItemIsSelectable;
     if(index.column() == ColumnFileName)
-      flags |= (Qt::ItemIsDragEnabled|Qt::ItemIsDropEnabled);
+      flags |= (Qt::ItemIsDragEnabled|Qt::ItemIsDropEnabled
+                |Qt::ItemIsEditable); // inline renaming
   }
   else {
     flags = Qt::ItemIsDropEnabled;

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -224,6 +224,7 @@ QVariant FolderModel::data(const QModelIndex & index, int role/* = Qt::DisplayRo
           return QString::fromUtf8(name);
         }
       }
+      break;
     }
     case Qt::DecorationRole: {
       if(index.column() == 0) {
@@ -236,7 +237,8 @@ QVariant FolderModel::data(const QModelIndex & index, int role/* = Qt::DisplayRo
     case Qt::EditRole: {
       if(index.column() == 0) {
         // inline renaming (see FolderItemDelegate::setEditorData())
-        return QVariant(item->displayName);
+        const char* name = fm_file_info_get_name(info);
+        return QString::fromUtf8(name);
       }
       break;
     }

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -39,7 +39,8 @@ Q_OBJECT
 public:
 
   enum Role {
-    FileInfoRole = Qt::UserRole
+    FileInfoRole = Qt::UserRole,
+    FileIsDirRole
   };
 
   enum ColumnId {

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -958,6 +958,13 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
         setCursor(Qt::ArrowCursor);
       break;
     case QEvent::Wheel:
+      // don't let the view scroll during an inline renaming
+      if (view && mode != DetailedListMode) {
+        FolderViewListView* listView = static_cast<FolderViewListView*>(view);
+        FolderItemDelegate* delegate = static_cast<FolderItemDelegate*>(listView->itemDelegateForColumn(FolderModel::ColumnFileName));
+        if (delegate->hasEditor())
+          return true;
+      }
       // This is to fix #85: Scrolling doesn't work in compact view
       // Actually, I think it's the bug of Qt, not ours.
       // When in compact mode, only the horizontal scroll bar is used and the vertical one is hidden.

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -153,6 +153,7 @@ public Q_SLOTS:
 private Q_SLOTS:
   void onAutoSelectionTimeout();
   void onSelChangedTimeout();
+  void onClosingEditor(QWidget* editor, QAbstractItemDelegate::EndEditHint hint);
 
 Q_SIGNALS:
   void clicked(int type, FmFileInfo* file);

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -65,6 +65,11 @@ Q_SIGNALS:
 
 private Q_SLOTS:
   void activation(const QModelIndex &index);
+  // inline renaming
+  void editActivated() {
+    if (currentIndex().isValid())
+      edit(currentIndex());
+  }
 
 private:
   bool activationAllowed_;

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -65,10 +65,14 @@ Q_SIGNALS:
 
 private Q_SLOTS:
   void activation(const QModelIndex &index);
+
   // inline renaming
   void editActivated() {
-    if (currentIndex().isValid())
-      edit(currentIndex());
+    QModelIndex cur = currentIndex();
+    if (cur.isValid()) {
+      scrollTo(cur);
+      edit(cur);
+    }
   }
 
 private:


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/468.

This is one of the possible implementations of inline renaming as a property of list views (icon, thumbnail and compact views) and independent of pcmanfm-qt, so that it's available to lximage-qt too. It coexists with dialog renaming and shares the same error dialogs with it.

Renaming of the current item is started by the context-menu "Rename" item when only one file/folder is selected, or by `Ctrl+R`. It is finished by Enter/Return or by removing focus from the item, and canceled by Esc. (`F2` is still for dialog renaming.)

If several items are selected, the context-menu "Rename" item will behave as before, namely it will call the rename dialog.

NOTE: Due to a design problem in pcmanfm-qt, desktop has its own `QStyledItemDelegate`. Therefore, its inline renaming should be implemented separately. I will make another PR for it.