### PR TITLE
GObjectPtr: Detect & handle "self-assignment"

### DIFF
--- a/src/core/gobjectptr.h
+++ b/src/core/gobjectptr.h
@@ -21,12 +21,10 @@ public:
             g_object_ref(gobj_);
     }
 
-    GObjectPtr(const GObjectPtr& other): GObjectPtr{} {
-        *this = other;
+    GObjectPtr(const GObjectPtr& other): gobj_{other.gobj_ ? reinterpret_cast<T*>(g_object_ref(other.gobj_)) : nullptr} {
     }
 
-    GObjectPtr(GObjectPtr&& other): GObjectPtr{} {
-        *this = other;
+    GObjectPtr(GObjectPtr&& other): gobj_{other.release()} {
     }
 
     ~GObjectPtr() {
@@ -51,6 +49,9 @@ public:
     }
 
     GObjectPtr& operator = (const GObjectPtr& other) {
+        if (*this == other)
+            return *this;
+
         if(gobj_ != nullptr)
             g_object_unref(gobj_);
         gobj_ = other.gobj_ ? reinterpret_cast<T*>(g_object_ref(other.gobj_)) : nullptr;
@@ -58,14 +59,19 @@ public:
     }
 
     GObjectPtr& operator = (GObjectPtr&& other) {
+        if (this == &other)
+            return *this;
+
         if(gobj_ != nullptr)
             g_object_unref(gobj_);
-        gobj_ = other.gobj_ ? reinterpret_cast<T*>(other.gobj_) : nullptr;
-        other.gobj_ = nullptr;
+        gobj_ = other.release();
         return *this;
     }
 
     GObjectPtr& operator = (T* gobj) {
+        if (*this == gobj)
+            return *this;
+
         if(gobj_ != nullptr)
             g_object_unref(gobj_);
         gobj_ = gobj ? reinterpret_cast<T*>(g_object_ref(gobj_)) : nullptr;


### PR DESCRIPTION
W/o checking if the we are assigning the "same" pointer, we can end in
letting the refcount go to zero. With "same" pointer check we also
eliminate unneed g_object_unref/g_object_ref pairs on the same pointer.

This simplified example shows the erroneous behavior and triggers the
"GLib-GObject-CRITICAL" messages:

```c++
Fm::GObjectPtr<GFile>& foo(Fm::GObjectPtr<GFile>& f)
{
    return f;
}

const Fm::GObjectPtr<GFile>& foo_const(const Fm::GObjectPtr<GFile>& f)
{
  return f;
}

int main(int argc, char **argv)
{
  std::cerr << "1\n";
  Fm::GObjectPtr<GFile> file{g_file_parse_name("test.txt"), false};
  GFile * f = file.get();
  file = f;

  std::cerr << "2\n";
  Fm::GObjectPtr<GFile> f2{g_file_parse_name("test2.txt"), false};
  f2 = foo(f2);

  std::cerr << "3\n";
  Fm::GObjectPtr<GFile> f3{g_file_parse_name("test3.txt"), false};
  const Fm::GObjectPtr<GFile> & f3_r{f3};
  f3 = foo_const(f3_r);

  std::cerr << "4\n";
  return 0;
}
```
Output:
```
1

(process:17367): GLib-GObject-CRITICAL **: g_object_ref: assertion 'G_IS_OBJECT (object)' failed
2

(process:17367): GLib-GObject-CRITICAL **: g_object_ref: assertion 'G_IS_OBJECT (object)' failed
3

(process:17367): GLib-GObject-CRITICAL **: g_object_ref: assertion 'G_IS_OBJECT (object)' failed
4
```