### PR TITLE
[WIP] Address compiler warnings

### DIFF
--- a/src/appchooserdialog.cpp
+++ b/src/appchooserdialog.cpp
@@ -48,7 +48,7 @@ bool AppChooserDialog::isSetDefault() const {
     return ui->setDefault->isChecked();
 }
 
-static void on_temp_appinfo_destroy(gpointer data, GObject* objptr) {
+static void on_temp_appinfo_destroy(gpointer data, GObject* /*objptr*/) {
     char* filename = (char*)data;
     if(g_unlink(filename) < 0) {
         g_critical("failed to remove %s", filename);

--- a/src/applaunchcontext.cpp
+++ b/src/applaunchcontext.cpp
@@ -28,7 +28,7 @@ typedef struct _FmAppLaunchContext {
 
 G_DEFINE_TYPE(FmAppLaunchContext, fm_app_launch_context, G_TYPE_APP_LAUNCH_CONTEXT)
 
-static char* fm_app_launch_context_get_display(GAppLaunchContext *context, GAppInfo *info, GList *files) {
+static char* fm_app_launch_context_get_display(GAppLaunchContext * /*context*/, GAppInfo * /*info*/, GList * /*files*/) {
   Display* dpy = QX11Info::display();
   if(dpy) {
     char* xstr = DisplayString(dpy);
@@ -37,7 +37,7 @@ static char* fm_app_launch_context_get_display(GAppLaunchContext *context, GAppI
   return nullptr;
 }
 
-static char* fm_app_launch_context_get_startup_notify_id(GAppLaunchContext *context, GAppInfo *info, GList *files) {
+static char* fm_app_launch_context_get_startup_notify_id(GAppLaunchContext * /*context*/, GAppInfo * /*info*/, GList * /*files*/) {
   return nullptr;
 }
 
@@ -47,10 +47,10 @@ static void fm_app_launch_context_class_init(FmAppLaunchContextClass* klass) {
   app_launch_class->get_startup_notify_id = fm_app_launch_context_get_startup_notify_id;
 }
 
-static void fm_app_launch_context_init(FmAppLaunchContext* context) {
+static void fm_app_launch_context_init(FmAppLaunchContext* /*context*/) {
 }
 
-FmAppLaunchContext* fm_app_launch_context_new_for_widget(QWidget* widget) {
+FmAppLaunchContext* fm_app_launch_context_new_for_widget(QWidget* /*widget*/) {
   FmAppLaunchContext* context = (FmAppLaunchContext*)g_object_new(FM_TYPE_APP_LAUNCH_CONTEXT, nullptr);
   return context;
 }

--- a/src/appmenuview.h
+++ b/src/appmenuview.h
@@ -51,7 +51,7 @@ public:
     bool isAppSelected() const;
 
 Q_SIGNALS:
-    void selectionChanged();
+    void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 
 private:
     void addMenuItems(QStandardItem* parentItem, MenuCacheDir* dir);

--- a/src/appmenuview_p.h
+++ b/src/appmenuview_p.h
@@ -51,7 +51,7 @@ public:
         return item_;
     }
 
-    MenuCacheType type() {
+    int type() const {
         return menu_cache_item_get_type(item_);
     }
 

--- a/src/browsehistory.cpp
+++ b/src/browsehistory.cpp
@@ -37,7 +37,7 @@ void BrowseHistory::add(Fm::FilePath path, int scrollPos) {
         items_.erase(items_.cbegin() + currentIndex_ + 1, items_.cend());
     }
 
-    if(items_.size() + 1 > maxCount_) {
+    if(items_.size() + 1 > static_cast<size_t>(maxCount_)) {
         // if there are too many items, remove the oldest one.
         // FIXME: what if currentIndex_ == 0? remove the last item instead?
         if(currentIndex_ == 0) {
@@ -54,7 +54,7 @@ void BrowseHistory::add(Fm::FilePath path, int scrollPos) {
 }
 
 void BrowseHistory::setCurrentIndex(int index) {
-    if(index >= 0 && index < items_.size()) {
+    if(index >= 0 && static_cast<size_t>(index) < items_.size()) {
         currentIndex_ = index;
         // FIXME: should we emit a signal for the change?
     }
@@ -72,7 +72,7 @@ int BrowseHistory::backward() {
 }
 
 bool BrowseHistory::canForward() const {
-    return (currentIndex_ + 1 < items_.size());
+    return (static_cast<size_t>(currentIndex_) + 1 < items_.size());
 }
 
 int BrowseHistory::forward() {
@@ -84,7 +84,7 @@ int BrowseHistory::forward() {
 
 void BrowseHistory::setMaxCount(int maxCount) {
     maxCount_ = maxCount;
-    if(items_.size() > maxCount) {
+    if(items_.size() > static_cast<size_t>(maxCount)) {
         // TODO: remove some items
     }
 }

--- a/src/core/bookmarks.cpp
+++ b/src/core/bookmarks.cpp
@@ -41,7 +41,7 @@ Bookmarks::~Bookmarks() {
 }
 
 const std::shared_ptr<const BookmarkItem>& Bookmarks::insert(const FilePath& path, const QString& name, int pos) {
-    const auto insert_pos = (pos < 0 || pos > items_.size()) ? items_.cend() : items_.cbegin() + pos;
+    const auto insert_pos = (pos < 0 || static_cast<size_t>(pos) > items_.size()) ? items_.cend() : items_.cbegin() + pos;
     auto it = items_.insert(insert_pos, std::make_shared<const BookmarkItem>(path, name));
     queueSave();
     return *it;
@@ -143,7 +143,7 @@ void Bookmarks::load() {
     }
 }
 
-void Bookmarks::onFileChanged(GFileMonitor* mon, GFile* gf, GFile* other, GFileMonitorEvent evt) {
+void Bookmarks::onFileChanged(GFileMonitor* /*mon*/, GFile* /*gf*/, GFile* /*other*/, GFileMonitorEvent /*evt*/) {
     // reload the bookmarks
     items_.clear();
     load();

--- a/src/core/copyjob.cpp
+++ b/src/core/copyjob.cpp
@@ -24,7 +24,7 @@ void CopyJob::gfileProgressCallback(goffset current_num_bytes, goffset total_num
     _this->setCurrentFileProgress(total_num_bytes, current_num_bytes);
 }
 
-bool CopyJob::copyRegularFile(const FilePath& srcPath, GFileInfoPtr srcFile, const FilePath& destPath) {
+bool CopyJob::copyRegularFile(const FilePath& srcPath, GFileInfoPtr /*srcFile*/, const FilePath& destPath) {
     int flags = G_FILE_COPY_ALL_METADATA | G_FILE_COPY_NOFOLLOW_SYMLINKS;
     GErrorPtr err;
 _retry_copy:
@@ -71,8 +71,6 @@ _retry_copy:
 #endif
         }
         else {
-            bool is_no_space = (err.domain() == G_IO_ERROR &&
-                                err.code() == G_IO_ERROR_NO_SPACE);
             ErrorAction act = emitError( err, ErrorSeverity::MODERATE);
             err.reset();
             if(act == ErrorAction::RETRY) {
@@ -80,6 +78,8 @@ _retry_copy:
                 goto _retry_copy;
             }
 # if 0
+            const bool is_no_space = (err.domain() == G_IO_ERROR &&
+                                err.code() == G_IO_ERROR_NO_SPACE);
             /* FIXME: ask to leave partial content? */
             if(is_no_space) {
                 g_file_delete(dest, fm_job_get_cancellable(fmjob), nullptr);
@@ -206,7 +206,6 @@ bool CopyJob::makeDir(const FilePath& srcPath, GFileInfoPtr srcFile, const FileP
         if(err->domain == G_IO_ERROR && (err->code == G_IO_ERROR_EXISTS ||
                                          err->code == G_IO_ERROR_INVALID_FILENAME ||
                                          err->code == G_IO_ERROR_FILENAME_TOO_LONG)) {
-            bool dest_exists = (err->code == G_IO_ERROR_EXISTS);
             GFileInfoPtr destFile;
             // FIXME: query its info
             FilePath newDestPath;

--- a/src/core/deletejob.cpp
+++ b/src/core/deletejob.cpp
@@ -112,7 +112,7 @@ bool DeleteJob::deleteDirContent(const FilePath& path, GFileInfoPtr inf) {
         }
         else {
             if(err) {
-                ErrorAction act = emitError(err, ErrorSeverity::MODERATE);
+                emitError(err, ErrorSeverity::MODERATE);
                 /* ErrorAction::RETRY is not supported here */
                 hasError = true;
             }

--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -6,7 +6,7 @@
 
 namespace Fm {
 
-DirListJob::DirListJob(const FilePath& path, Flags flags): dir_path{path} {
+DirListJob::DirListJob(const FilePath& path, Flags _flags): dir_path{path}, flags{_flags} {
 }
 
 void DirListJob::exec() {

--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<Folder> Folder::fromPath(const FilePath& path) {
     return folder;
 }
 
-bool Folder::makeDirectory(const char* name, GError** error) {
+bool Folder::makeDirectory(const char* /*name*/, GError** /*error*/) {
     // TODO:
     // FIXME: what the API is used for in the original libfm C API?
     return false;
@@ -413,7 +413,7 @@ void Folder::onDirChanged(GFileMonitorEvent evt) {
     }
 }
 
-void Folder::onFileChangeEvents(GFileMonitor* monitor, GFile* gf, GFile* other_file, GFileMonitorEvent evt) {
+void Folder::onFileChangeEvents(GFileMonitor* /*monitor*/, GFile* gf, GFile* /*other_file*/, GFileMonitorEvent evt) {
     /* const char* names[]={
         "G_FILE_MONITOR_EVENT_CHANGED",
         "G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT",

--- a/src/core/iconinfo_p.h
+++ b/src/core/iconinfo_p.h
@@ -37,10 +37,10 @@ public:
     virtual QSize actualSize(const QSize& size, QIcon::Mode mode, QIcon::State state) override;
 
     // not supported
-    virtual void addFile(const QString& fileName, const QSize& size, QIcon::Mode mode, QIcon::State state) override {}
+    virtual void addFile(const QString& /*fileName*/, const QSize& /*size*/, QIcon::Mode /*mode*/, QIcon::State /*state*/) override {}
 
     // not supported
-    virtual void addPixmap(const QPixmap& pixmap, QIcon::Mode mode, QIcon::State state) override {}
+    virtual void addPixmap(const QPixmap& /*pixmap*/, QIcon::Mode /*mode*/, QIcon::State /*state*/) override {}
 
     virtual QIconEngine* clone() const override;
 

--- a/src/core/job.h
+++ b/src/core/job.h
@@ -104,7 +104,7 @@ private:
         _this->onCancellableCancelled(cancellable);
     }
 
-    void onCancellableCancelled(GCancellable* cancellable) {
+    void onCancellableCancelled(GCancellable* /*cancellable*/) {
         Q_EMIT cancelled();
     }
 

--- a/src/core/terminal.cpp
+++ b/src/core/terminal.cpp
@@ -23,8 +23,6 @@ bool launchTerminal(const char* programName, const FilePath& workingDir, Fm::GEr
         g_key_file_free(kf);
         return false;
     }
-    auto open_arg = g_key_file_get_string(kf, programName, "open_arg", nullptr);
-    auto noclose_arg = g_key_file_get_string(kf, programName, "noclose_arg", nullptr);
     auto launch = g_key_file_get_string(kf, programName, "launch", nullptr);
     auto desktop_id = g_key_file_get_string(kf, programName, "desktop_id", nullptr);
 

--- a/src/core/thumbnailer.cpp
+++ b/src/core/thumbnailer.cpp
@@ -12,8 +12,8 @@ std::vector<std::shared_ptr<Thumbnailer>> Thumbnailer::allThumbnailers_;
 
 Thumbnailer::Thumbnailer(const char* id, GKeyFile* kf):
     id_{g_strdup(id)},
-    exec_{g_key_file_get_string(kf, "Thumbnailer Entry", "Exec", nullptr)},
-    try_exec_{g_key_file_get_string(kf, "Thumbnailer Entry", "TryExec", nullptr)} {
+    try_exec_{g_key_file_get_string(kf, "Thumbnailer Entry", "TryExec", nullptr)},
+    exec_{g_key_file_get_string(kf, "Thumbnailer Entry", "Exec", nullptr)} {
 }
 
 CStrPtr Thumbnailer::commandForUri(const char* uri, const char* output_file, guint size) const {

--- a/src/core/totalsizejob.cpp
+++ b/src/core/totalsizejob.cpp
@@ -111,7 +111,7 @@ _retry_enum_children:
                     else {
                         if(err) { /* error! */
                             /* ErrorAction::RETRY is not supported */
-                            ErrorAction act = emitError( err, ErrorSeverity::MILD);
+                            emitError( err, ErrorSeverity::MILD);
                             err = nullptr;
                         }
                         else {

--- a/src/core/volumemanager.h
+++ b/src/core/volumemanager.h
@@ -192,32 +192,32 @@ private:
         void exec() override;
     };
 
-    static void _onGVolumeAdded(GVolumeMonitor* mon, GVolume* vol, VolumeManager* _this) {
+    static void _onGVolumeAdded(GVolumeMonitor* /*mon*/, GVolume* vol, VolumeManager* _this) {
         _this->onGVolumeAdded(vol);
     }
     void onGVolumeAdded(GVolume* vol);
 
-    static void _onGVolumeRemoved(GVolumeMonitor* mon, GVolume* vol, VolumeManager* _this) {
+    static void _onGVolumeRemoved(GVolumeMonitor* /*mon*/, GVolume* vol, VolumeManager* _this) {
         _this->onGVolumeRemoved(vol);
     }
     void onGVolumeRemoved(GVolume* vol);
 
-    static void _onGVolumeChanged(GVolumeMonitor* mon, GVolume* vol, VolumeManager* _this) {
+    static void _onGVolumeChanged(GVolumeMonitor* /*mon*/, GVolume* vol, VolumeManager* _this) {
         _this->onGVolumeChanged(vol);
     }
     void onGVolumeChanged(GVolume* vol);
 
-    static void _onGMountAdded(GVolumeMonitor* mon, GMount* mnt, VolumeManager* _this) {
+    static void _onGMountAdded(GVolumeMonitor* /*mon*/, GMount* mnt, VolumeManager* _this) {
         _this->onGMountAdded(mnt);
     }
     void onGMountAdded(GMount* mnt);
 
-    static void _onGMountRemoved(GVolumeMonitor* mon, GMount* mnt, VolumeManager* _this) {
+    static void _onGMountRemoved(GVolumeMonitor* /*mon*/, GMount* mnt, VolumeManager* _this) {
         _this->onGMountRemoved(mnt);
     }
     void onGMountRemoved(GMount* mnt);
 
-    static void _onGMountChanged(GVolumeMonitor* mon, GMount* mnt, VolumeManager* _this) {
+    static void _onGMountChanged(GVolumeMonitor* /*mon*/, GMount* mnt, VolumeManager* _this) {
         _this->onGMountChanged(mnt);
     }
     void onGMountChanged(GMount* mnt);

--- a/src/customactions/fileactioncondition.cpp
+++ b/src/customactions/fileactioncondition.cpp
@@ -429,7 +429,7 @@ bool FileActionCondition::match_folders(const FileInfoList& files) {
 }
 
 bool FileActionCondition::match_selection_count(const FileInfoList& files) {
-    uint n_files = files.size();
+    const int n_files = files.size();
     switch(selection_count_cmp) {
     case '<':
         if(n_files >= selection_count) {
@@ -450,7 +450,7 @@ bool FileActionCondition::match_selection_count(const FileInfoList& files) {
     return true;
 }
 
-bool FileActionCondition::match_capabilities(const FileInfoList& files) {
+bool FileActionCondition::match_capabilities(const FileInfoList& /*files*/) {
     // TODO
     return true;
 }

--- a/src/customactions/fileactionprofile.cpp
+++ b/src/customactions/fileactionprofile.cpp
@@ -41,7 +41,7 @@ FileActionProfile::FileActionProfile(GKeyFile *kf, const char* profile_name) {
 }
 
 
-bool FileActionProfile::launch_once(GAppLaunchContext* ctx, std::shared_ptr<const FileInfo> first_file, const FileInfoList& files, CStrPtr& output) {
+bool FileActionProfile::launch_once(GAppLaunchContext* /*ctx*/, std::shared_ptr<const FileInfo> first_file, const FileInfoList& files, CStrPtr& output) {
     if(exec == nullptr) {
         return false;
     }

--- a/src/dirtreemodel.cpp
+++ b/src/dirtreemodel.cpp
@@ -25,6 +25,7 @@
 namespace Fm {
 
 DirTreeModel::DirTreeModel(QObject* parent):
+    QAbstractItemModel(parent),
     showHidden_(false) {
 }
 
@@ -36,6 +37,7 @@ void DirTreeModel::addRoots(Fm::FilePathList rootPaths) {
     job->setAutoDelete(true);
     connect(job, &Fm::FileInfoJob::finished, this, &DirTreeModel::onFileInfoJobFinished, Qt::BlockingQueuedConnection);
     job->runAsync();
+    return QModelIndex{};
 }
 
 void DirTreeModel::onFileInfoJobFinished() {
@@ -79,7 +81,7 @@ QVariant DirTreeModel::data(const QModelIndex& index, int role) const {
     return QVariant();
 }
 
-int DirTreeModel::columnCount(const QModelIndex& parent) const {
+int DirTreeModel::columnCount(const QModelIndex& /*parent*/) const {
     return 1;
 }
 
@@ -113,14 +115,14 @@ QModelIndex DirTreeModel::parent(const QModelIndex& child) const {
 QModelIndex DirTreeModel::index(int row, int column, const QModelIndex& parent) const {
     if(row >= 0 && column >= 0 && column == 0) {
         if(!parent.isValid()) { // root items
-            if(row < rootItems_.size()) {
+            if(static_cast<size_t>(row) < rootItems_.size()) {
                 const DirTreeModelItem* item = rootItems_.at(row);
                 return createIndex(row, column, (void*)item);
             }
         }
         else { // child items
             DirTreeModelItem* parentItem = itemFromIndex(parent);
-            if(row < parentItem->children_.size()) {
+            if(static_cast<size_t>(row) < parentItem->children_.size()) {
                 const DirTreeModelItem* item = parentItem->children_.at(row);
                 return createIndex(row, column, (void*)item);
             }

--- a/src/dirtreeview.cpp
+++ b/src/dirtreeview.cpp
@@ -30,6 +30,7 @@
 namespace Fm {
 
 DirTreeView::DirTreeView(QWidget* parent):
+    QTreeView(parent),
     currentExpandingItem_(nullptr) {
 
     setSelectionMode(QAbstractItemView::SingleSelection);
@@ -274,7 +275,7 @@ void DirTreeView::onExpanded(const QModelIndex& index) {
     }
 }
 
-void DirTreeView::onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected) {
+void DirTreeView::onSelectionChanged(const QItemSelection& selected, const QItemSelection& /*deselected*/) {
     if(!selected.isEmpty()) {
         QModelIndex index = selected.first().topLeft();
         DirTreeModel* _model = static_cast<DirTreeModel*>(model());

--- a/src/dnddest.cpp
+++ b/src/dnddest.cpp
@@ -59,11 +59,11 @@ bool DndDest::dropMimeData(const QMimeData* data, Qt::DropAction action) {
   return false;
 }
 
-bool DndDest::isSupported(const QMimeData* data) {
+bool DndDest::isSupported(const QMimeData* /*data*/) {
   return false;
 }
 
-bool DndDest::isSupported(QString mimeType) {
+bool DndDest::isSupported(QString /*mimeType*/) {
   return false;
 }
 

--- a/src/filelauncher.cpp
+++ b/src/filelauncher.cpp
@@ -34,7 +34,8 @@ FmFileLauncher FileLauncher::funcs = {
     (FmLaunchFolderFunc)FileLauncher::_openFolder,
     FileLauncher::_execFile,
     FileLauncher::_error,
-    FileLauncher::_ask
+    FileLauncher::_ask,
+    nullptr
 };
 
 FileLauncher::FileLauncher():
@@ -76,7 +77,7 @@ bool FileLauncher::launchPaths(QWidget* parent, GList* paths) {
     return ret;
 }
 
-GAppInfo* FileLauncher::getApp(GList* file_infos, FmMimeType* mime_type, GError** err) {
+GAppInfo* FileLauncher::getApp(GList* /*file_infos*/, FmMimeType* mime_type, GError** /*err*/) {
     AppChooserDialog dlg(nullptr);
     if(mime_type) {
         dlg.setMimeType(Fm::MimeType::fromName(fm_mime_type_get_type(mime_type)));
@@ -92,7 +93,7 @@ GAppInfo* FileLauncher::getApp(GList* file_infos, FmMimeType* mime_type, GError*
     return nullptr;
 }
 
-bool FileLauncher::openFolder(GAppLaunchContext* ctx, GList* folder_infos, GError** err) {
+bool FileLauncher::openFolder(GAppLaunchContext* /*ctx*/, GList* folder_infos, GError** /*err*/) {
     for(GList* l = folder_infos; l; l = l->next) {
         FmFileInfo* fi = FM_FILE_INFO(l->data);
         qDebug() << "  folder:" << QString::fromUtf8(fm_file_info_get_disp_name(fi));
@@ -118,13 +119,13 @@ FmFileLauncherExecAction FileLauncher::execFile(FmFileInfo* file) {
     return res;
 }
 
-int FileLauncher::ask(const char* msg, char* const* btn_labels, int default_btn) {
+int FileLauncher::ask(const char* /*msg*/, char* const* /*btn_labels*/, int /*default_btn*/) {
     /* FIXME: set default button properly */
     // return fm_askv(data->parent, nullptr, msg, btn_labels);
     return -1;
 }
 
-bool FileLauncher::error(GAppLaunchContext* ctx, GError* err, FmPath* path) {
+bool FileLauncher::error(GAppLaunchContext* /*ctx*/, GError* err, FmPath* path) {
     /* ask for mount if trying to launch unmounted path */
     if(err->domain == G_IO_ERROR) {
         if(path && err->code == G_IO_ERROR_NOT_MOUNTED) {

--- a/src/fileoperation.cpp
+++ b/src/fileoperation.cpp
@@ -134,7 +134,7 @@ void FileOperation::showDialog() {
     }
 }
 
-gint FileOperation::onFileOpsJobAsk(FmFileOpsJob* job, const char* question, char* const* options, FileOperation* pThis) {
+gint FileOperation::onFileOpsJobAsk(FmFileOpsJob* /*job*/, const char* question, char* const* options, FileOperation* pThis) {
     pThis->pauseElapsedTimer();
     pThis->showDialog();
     int ret = pThis->dlg->ask(QString::fromUtf8(question), options);
@@ -142,7 +142,7 @@ gint FileOperation::onFileOpsJobAsk(FmFileOpsJob* job, const char* question, cha
     return ret;
 }
 
-gint FileOperation::onFileOpsJobAskRename(FmFileOpsJob* job, FmFileInfo* src, FmFileInfo* dest, char** new_name, FileOperation* pThis) {
+gint FileOperation::onFileOpsJobAskRename(FmFileOpsJob* /*job*/, FmFileInfo* src, FmFileInfo* dest, char** new_name, FileOperation* pThis) {
     pThis->pauseElapsedTimer();
     pThis->showDialog();
     QString newName;
@@ -154,11 +154,11 @@ gint FileOperation::onFileOpsJobAskRename(FmFileOpsJob* job, FmFileInfo* src, Fm
     return ret;
 }
 
-void FileOperation::onFileOpsJobCancelled(FmFileOpsJob* job, FileOperation* pThis) {
+void FileOperation::onFileOpsJobCancelled(FmFileOpsJob* /*job*/, FileOperation* /*pThis*/) {
     qDebug("file operation is cancelled!");
 }
 
-void FileOperation::onFileOpsJobCurFile(FmFileOpsJob* job, const char* cur_file, FileOperation* pThis) {
+void FileOperation::onFileOpsJobCurFile(FmFileOpsJob* /*job*/, const char* cur_file, FileOperation* pThis) {
     pThis->curFile = QString::fromUtf8(cur_file);
 
     // We update the current file name in a timeout slot because drawing a string
@@ -168,7 +168,7 @@ void FileOperation::onFileOpsJobCurFile(FmFileOpsJob* job, const char* cur_file,
     //  pThis->dlg->setCurFile(pThis->curFile);
 }
 
-FmJobErrorAction FileOperation::onFileOpsJobError(FmFileOpsJob* job, GError* err, FmJobErrorSeverity severity, FileOperation* pThis) {
+FmJobErrorAction FileOperation::onFileOpsJobError(FmFileOpsJob* /*job*/, GError* err, FmJobErrorSeverity severity, FileOperation* pThis) {
     pThis->pauseElapsedTimer();
     pThis->showDialog();
     FmJobErrorAction act = pThis->dlg->error(err, severity);
@@ -176,17 +176,17 @@ FmJobErrorAction FileOperation::onFileOpsJobError(FmFileOpsJob* job, GError* err
     return act;
 }
 
-void FileOperation::onFileOpsJobFinished(FmFileOpsJob* job, FileOperation* pThis) {
+void FileOperation::onFileOpsJobFinished(FmFileOpsJob* /*job*/, FileOperation* pThis) {
     pThis->handleFinish();
 }
 
-void FileOperation::onFileOpsJobPercent(FmFileOpsJob* job, guint percent, FileOperation* pThis) {
+void FileOperation::onFileOpsJobPercent(FmFileOpsJob* /*job*/, guint percent, FileOperation* pThis) {
     if(pThis->dlg) {
         pThis->dlg->setPercent(percent);
     }
 }
 
-void FileOperation::onFileOpsJobPrepared(FmFileOpsJob* job, FileOperation* pThis) {
+void FileOperation::onFileOpsJobPrepared(FmFileOpsJob* /*job*/, FileOperation* pThis) {
     if(!pThis->elapsedTimer_) {
         pThis->elapsedTimer_ = new QElapsedTimer();
         pThis->elapsedTimer_->start();
@@ -242,7 +242,7 @@ void FileOperation::handleFinish() {
 
 // static
 FileOperation* FileOperation::copyFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent) {
-    FileOperation* op = new FileOperation(FileOperation::Copy, std::move(srcFiles));
+    FileOperation* op = new FileOperation(FileOperation::Copy, std::move(srcFiles), parent);
     op->setDestination(dest);
     op->run();
     return op;
@@ -250,7 +250,7 @@ FileOperation* FileOperation::copyFiles(Fm::FilePathList srcFiles, Fm::FilePath 
 
 // static
 FileOperation* FileOperation::moveFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent) {
-    FileOperation* op = new FileOperation(FileOperation::Move, std::move(srcFiles));
+    FileOperation* op = new FileOperation(FileOperation::Move, std::move(srcFiles), parent);
     op->setDestination(dest);
     op->run();
     return op;
@@ -258,7 +258,7 @@ FileOperation* FileOperation::moveFiles(Fm::FilePathList srcFiles, Fm::FilePath 
 
 //static
 FileOperation* FileOperation::symlinkFiles(Fm::FilePathList srcFiles, Fm::FilePath dest, QWidget* parent) {
-    FileOperation* op = new FileOperation(FileOperation::Link, std::move(srcFiles));
+    FileOperation* op = new FileOperation(FileOperation::Link, std::move(srcFiles), parent);
     op->setDestination(dest);
     op->run();
     return op;
@@ -300,7 +300,7 @@ FileOperation* FileOperation::trashFiles(Fm::FilePathList srcFiles, bool prompt,
 
 //static
 FileOperation* FileOperation::unTrashFiles(Fm::FilePathList srcFiles, QWidget* parent) {
-    FileOperation* op = new FileOperation(FileOperation::UnTrash, std::move(srcFiles));
+    FileOperation* op = new FileOperation(FileOperation::UnTrash, std::move(srcFiles), parent);
     op->run();
     return op;
 }
@@ -308,7 +308,7 @@ FileOperation* FileOperation::unTrashFiles(Fm::FilePathList srcFiles, QWidget* p
 // static
 FileOperation* FileOperation::changeAttrFiles(Fm::FilePathList srcFiles, QWidget* parent) {
     //TODO
-    FileOperation* op = new FileOperation(FileOperation::ChangeAttr, std::move(srcFiles));
+    FileOperation* op = new FileOperation(FileOperation::ChangeAttr, std::move(srcFiles), parent);
     op->run();
     return op;
 }

--- a/src/fileoperationdialog.cpp
+++ b/src/fileoperationdialog.cpp
@@ -91,7 +91,7 @@ void FileOperationDialog::setSourceFiles(const Fm::FilePathList &srcFiles) {
     }
 }
 
-int FileOperationDialog::ask(QString question, char* const* options) {
+int FileOperationDialog::ask(QString /*question*/, char* const* /*options*/) {
     // TODO: implement FileOperationDialog::ask()
     return 0;
 }

--- a/src/filepropsdialog.cpp
+++ b/src/filepropsdialog.cpp
@@ -119,10 +119,10 @@ void FilePropsDialog::initPermissionsPage() {
             hasDir = true;    // the files list contains dir(s)
         }
 
-        if(uid != DIFFERENT_UIDS && uid != fi->uid()) {
+        if(uid != DIFFERENT_UIDS && static_cast<uid_t>(uid) != fi->uid()) {
             uid = DIFFERENT_UIDS;    // not all files have the same owner
         }
-        if(gid != DIFFERENT_GIDS && gid != fi->gid()) {
+        if(gid != DIFFERENT_GIDS && static_cast<gid_t>(gid) != fi->gid()) {
             gid = DIFFERENT_GIDS;    // not all files have the same owner group
         }
 
@@ -352,8 +352,8 @@ void FilePropsDialog::accept() {
     }
 
     // check if chown or chmod is needed
-    guint32 newUid = uidFromName(ui->owner->text());
-    guint32 newGid = gidFromName(ui->ownerGroup->text());
+    gint32 newUid = uidFromName(ui->owner->text());
+    gint32 newGid = gidFromName(ui->ownerGroup->text());
     bool needChown = (newUid != -1 && newUid != uid) || (newGid != -1 && newGid != gid);
 
     int newOwnerPermSel = ui->ownerPerm->currentIndex();

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -228,7 +228,7 @@ void FolderMenu::onInvertSelectionActionTriggered() {
     view_->invertSelection();
 }
 
-void FolderMenu::onSortActionTriggered(bool checked) {
+void FolderMenu::onSortActionTriggered(bool /*checked*/) {
     ProxyFolderModel* model = view_->model();
 
     if(model) {
@@ -243,7 +243,7 @@ void FolderMenu::onSortActionTriggered(bool checked) {
     }
 }
 
-void FolderMenu::onSortOrderActionTriggered(bool checked) {
+void FolderMenu::onSortOrderActionTriggered(bool /*checked*/) {
     ProxyFolderModel* model = view_->model();
 
     if(model) {

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -248,7 +248,7 @@ QVariant FolderModel::headerData(int section, Qt::Orientation orientation, int r
     return QVariant();
 }
 
-QModelIndex FolderModel::index(int row, int column, const QModelIndex& parent) const {
+QModelIndex FolderModel::index(int row, int column, const QModelIndex& /*parent*/) const {
     if(row < 0 || row >= items.size() || column < 0 || column >= NumOfColumns) {
         return QModelIndex();
     }
@@ -256,7 +256,7 @@ QModelIndex FolderModel::index(int row, int column, const QModelIndex& parent) c
     return createIndex(row, column, (void*)&item);
 }
 
-QModelIndex FolderModel::parent(const QModelIndex& index) const {
+QModelIndex FolderModel::parent(const QModelIndex& /*index*/) const {
     return QModelIndex();
 }
 

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -350,8 +350,8 @@ void FolderViewTreeView::rowsAboutToBeRemoved(const QModelIndex& parent, int sta
     queueLayoutColumns();
 }
 
-void FolderViewTreeView::dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight) {
-    QTreeView::dataChanged(topLeft, bottomRight);
+void FolderViewTreeView::dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>& roles /*= QVector<int>{}*/) {
+    QTreeView::dataChanged(topLeft, bottomRight, roles);
     // FIXME: this will be very inefficient
     // queueLayoutColumns();
 }
@@ -467,7 +467,7 @@ void FolderView::onSelChangedTimeout() {
     Q_EMIT selChanged();
 }
 
-void FolderView::onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected) {
+void FolderView::onSelectionChanged(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/) {
     // It's possible that the selected items change too often and this slot gets called for thousands of times.
     // For example, when you select thousands of files and delete them, we will get one selectionChanged() event
     // for every deleted file. So, we use a timer to delay the handling to avoid too frequent updates of the UI.
@@ -867,7 +867,7 @@ void FolderView::childDragLeaveEvent(QDragLeaveEvent* e) {
     e->accept();
 }
 
-void FolderView::childDragMoveEvent(QDragMoveEvent* e) {
+void FolderView::childDragMoveEvent(QDragMoveEvent* /*e*/) {
     qDebug("drag move");
 }
 
@@ -1087,8 +1087,8 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
     }
 }
 
-void FolderView::prepareFileMenu(FileMenu* menu) {
+void FolderView::prepareFileMenu(FileMenu* /*menu*/) {
 }
 
-void FolderView::prepareFolderMenu(FolderMenu* menu) {
+void FolderView::prepareFolderMenu(FolderMenu* /*menu*/) {
 }

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -90,7 +90,7 @@ public:
 
   virtual void rowsInserted(const QModelIndex& parent,int start, int end);
   virtual void rowsAboutToBeRemoved(const QModelIndex& parent,int start, int end);
-  virtual void dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
+  virtual void dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>& roles = QVector<int>{});
   virtual void reset();
 
   virtual void resizeEvent(QResizeEvent* event);

--- a/src/libfmqt.cpp
+++ b/src/libfmqt.cpp
@@ -40,7 +40,7 @@ struct LibFmQtData {
 
 static LibFmQtData* theLibFmData = nullptr;
 
-static GFile* lookupCustomUri(GVfs *vfs, const char *identifier, gpointer user_data) {
+static GFile* lookupCustomUri(GVfs * /*vfs*/, const char *identifier, gpointer /*user_data*/) {
     GFile* gf = fm_file_new_for_uri(identifier);
     return gf;
 }

--- a/src/mountoperation.cpp
+++ b/src/mountoperation.cpp
@@ -83,11 +83,11 @@ MountOperation::~MountOperation() {
     // qDebug("MountOperation deleted");
 }
 
-void MountOperation::onAbort(GMountOperation* _op, MountOperation* pThis) {
+void MountOperation::onAbort(GMountOperation* /*_op*/, MountOperation* /*pThis*/) {
 
 }
 
-void MountOperation::onAskPassword(GMountOperation* _op, gchar* message, gchar* default_user, gchar* default_domain, GAskPasswordFlags flags, MountOperation* pThis) {
+void MountOperation::onAskPassword(GMountOperation* /*_op*/, gchar* message, gchar* default_user, gchar* default_domain, GAskPasswordFlags flags, MountOperation* pThis) {
     qDebug("ask password");
     MountOperationPasswordDialog dlg(pThis, flags);
     dlg.setMessage(QString::fromUtf8(message));
@@ -96,7 +96,7 @@ void MountOperation::onAskPassword(GMountOperation* _op, gchar* message, gchar* 
     dlg.exec();
 }
 
-void MountOperation::onAskQuestion(GMountOperation* _op, gchar* message, GStrv choices, MountOperation* pThis) {
+void MountOperation::onAskQuestion(GMountOperation* /*_op*/, gchar* message, GStrv choices, MountOperation* pThis) {
     qDebug("ask question");
     MountOperationQuestionDialog dialog(pThis, message, choices);
     dialog.exec();
@@ -108,11 +108,11 @@ void MountOperation::onReply(GMountOperation* _op, GMountOperationResult result,
 }
 */
 
-void MountOperation::onShowProcesses(GMountOperation* _op, gchar* message, GArray* processes, GStrv choices, MountOperation* pThis) {
+void MountOperation::onShowProcesses(GMountOperation* /*_op*/, gchar* /*message*/, GArray* /*processes*/, GStrv /*choices*/, MountOperation* /*pThis*/) {
     qDebug("show processes");
 }
 
-void MountOperation::onShowUnmountProgress(GMountOperation* _op, gchar* message, gint64 time_left, gint64 bytes_left, MountOperation* pThis) {
+void MountOperation::onShowUnmountProgress(GMountOperation* /*_op*/, gchar* /*message*/, gint64 /*time_left*/, gint64 /*bytes_left*/, MountOperation* /*pThis*/) {
     qDebug("show unmount progress");
 }
 
@@ -162,7 +162,7 @@ void MountOperation::onUnmountMountFinished(GMount* mount, GAsyncResult* res, QP
 }
 
 void MountOperation::handleFinish(GError* error) {
-    qDebug("operation finished: %p", error);
+    qDebug("operation finished: %p", static_cast<void *>(error));
     if(error) {
         bool showError = interactive_;
         if(error->domain == G_IO_ERROR) {

--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -177,7 +177,7 @@ PlacesModel::~PlacesModel() {
 }
 
 // static
-void PlacesModel::onTrashChanged(GFileMonitor* monitor, GFile* gf, GFile* other, GFileMonitorEvent evt, PlacesModel* pThis) {
+void PlacesModel::onTrashChanged(GFileMonitor* /*monitor*/, GFile* /*gf*/, GFile* /*other*/, GFileMonitorEvent /*evt*/, PlacesModel* pThis) {
     QTimer::singleShot(0, pThis, SLOT(updateTrash()));
 }
 
@@ -197,7 +197,7 @@ void PlacesModel::updateTrash() {
     if(trashItem_) {
         UpdateTrashData* data = new UpdateTrashData(this);
         g_file_query_info_async(data->gf, G_FILE_ATTRIBUTE_TRASH_ITEM_COUNT, G_FILE_QUERY_INFO_NONE, G_PRIORITY_LOW, nullptr,
-        [](GObject * source_object, GAsyncResult * res, gpointer user_data) {
+        [](GObject * /*source_object*/, GAsyncResult * res, gpointer user_data) {
             // the callback lambda function is called when the asyn query operation is finished
             UpdateTrashData* data = reinterpret_cast<UpdateTrashData*>(user_data);
             PlacesModel* _this = data->model.data();
@@ -332,7 +332,7 @@ PlacesModelBookmarkItem* PlacesModel::itemFromBookmark(std::shared_ptr<const Fm:
     return nullptr;
 }
 
-void PlacesModel::onMountAdded(GVolumeMonitor* monitor, GMount* mount, PlacesModel* pThis) {
+void PlacesModel::onMountAdded(GVolumeMonitor* /*monitor*/, GMount* mount, PlacesModel* pThis) {
     // according to gio API doc, a shadowed mount should not be visible to the user
 #if GLIB_CHECK_VERSION(2, 20, 0)
     if(g_mount_is_shadowed(mount)) {
@@ -428,7 +428,7 @@ void PlacesModel::onMountRemoved(GVolumeMonitor* monitor, GMount* mount, PlacesM
 #endif
 }
 
-void PlacesModel::onVolumeAdded(GVolumeMonitor* monitor, GVolume* volume, PlacesModel* pThis) {
+void PlacesModel::onVolumeAdded(GVolumeMonitor* /*monitor*/, GVolume* volume, PlacesModel* pThis) {
     // for some unknown reasons, sometimes we get repeated volume-added
     // signals and added a device more than one. So, make a sanity check here.
     PlacesModelVolumeItem* volumeItem = pThis->itemFromVolume(volume);
@@ -442,7 +442,7 @@ void PlacesModel::onVolumeAdded(GVolumeMonitor* monitor, GVolume* volume, Places
     }
 }
 
-void PlacesModel::onVolumeChanged(GVolumeMonitor* monitor, GVolume* volume, PlacesModel* pThis) {
+void PlacesModel::onVolumeChanged(GVolumeMonitor* /*monitor*/, GVolume* volume, PlacesModel* pThis) {
     PlacesModelVolumeItem* item = pThis->itemFromVolume(volume);
     if(item) {
         item->update();
@@ -455,7 +455,7 @@ void PlacesModel::onVolumeChanged(GVolumeMonitor* monitor, GVolume* volume, Plac
     }
 }
 
-void PlacesModel::onVolumeRemoved(GVolumeMonitor* monitor, GVolume* volume, PlacesModel* pThis) {
+void PlacesModel::onVolumeRemoved(GVolumeMonitor* /*monitor*/, GVolume* volume, PlacesModel* pThis) {
     PlacesModelVolumeItem* item = pThis->itemFromVolume(volume);
     if(item) {
         pThis->devicesRoot->removeRow(item->row());
@@ -509,7 +509,7 @@ std::shared_ptr<PlacesModel> PlacesModel::globalInstance() {
 }
 
 
-bool PlacesModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) {
+bool PlacesModel::dropMimeData(const QMimeData* data, Qt::DropAction /*action*/, int row, int column, const QModelIndex& parent) {
     QStandardItem* item = itemFromIndex(parent);
     if(data->hasFormat("application/x-bookmark-row")) { // the data being dopped is a bookmark row
         // decode it and do bookmark reordering

--- a/src/placesview.h
+++ b/src/placesview.h
@@ -84,7 +84,7 @@ protected Q_SLOTS:
     void onRenameBookmark();
 
 protected:
-    void drawBranches(QPainter* painter, const QRect& rect, const QModelIndex& index) const {
+    void drawBranches(QPainter* /*painter*/, const QRect& /*rect*/, const QModelIndex& /*index*/) const {
         // override this method to inhibit drawing of the branch grid lines by Qt.
     }
 

--- a/src/sidepane.cpp
+++ b/src/sidepane.cpp
@@ -111,7 +111,7 @@ const char* SidePane::modeName(SidePane::Mode mode) {
     }
 }
 
-bool SidePane::setHomeDir(const char* home_dir) {
+bool SidePane::setHomeDir(const char* /*home_dir*/) {
     if(view_ == nullptr) {
         return false;
     }

--- a/src/xdndworkaround.cpp
+++ b/src/xdndworkaround.cpp
@@ -83,7 +83,7 @@ XdndWorkaround::~XdndWorkaround() {
     qApp->removeNativeEventFilter(this);
 }
 
-bool XdndWorkaround::nativeEventFilter(const QByteArray& eventType, void* message, long* result) {
+bool XdndWorkaround::nativeEventFilter(const QByteArray& eventType, void* message, long* /*result*/) {
     if(Q_LIKELY(eventType == "xcb_generic_event_t")) {
         xcb_generic_event_t* event = static_cast<xcb_generic_event_t*>(message);
         switch(event->response_type & ~0x80) {


### PR DESCRIPTION
Warnings left:
- [x] copy elision & std::move (addressed in #70)
- [x] usage of deprecated `Fm::_convertPathList`, `Fm::_convertPath` -> ~~we should either undeprecate them or do not use them~~
- [x] unused variable `trash_query` -> ~~the untrash job seems to be unimplemented !?~~

Update: the last two are valid/needed warnings as the porting process is ongoing...