### PR TITLE
Don't make items current on mouseover

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -918,9 +918,6 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
                 QModelIndex index = view->indexAt(hoverEvent->pos()); // find out the hovered item
                 if(index.isValid()) { // change the cursor to a hand when hovering on an item
                     setCursor(Qt::PointingHandCursor);
-                    if(!selectionModel()->hasSelection()) {
-                        selectionModel()->setCurrentIndex(index, QItemSelectionModel::Current);
-                    }
                 }
                 else {
                     setCursor(Qt::ArrowCursor);


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/470.

This is about a usability issue I encountered when comparing PCManFM-Qt to Dolphin. The "focus rectangle", which is for keyboard navigation, would be useless if items were made current on mouseover.