### PR TITLE
Replace start tilde in PathEdit

### DIFF
--- a/src/pathedit.h
+++ b/src/pathedit.h
@@ -45,6 +45,7 @@ protected:
 
 private Q_SLOTS:
     void onTextChanged(const QString& text);
+    void onTextEdited(const QString& text);
 
 private:
     void autoComplete();


### PR DESCRIPTION
This follows https://github.com/lxde/pcmanfm-qt/pull/481.

Since neither `Fm::FilePath` nor autocompletion understands a starting tilde, this is the safest and easiest way of letting users type it in the location bar with autocompletion, IMO.