### PR TITLE
Continue file selection on next/previous row

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -182,6 +182,26 @@ void FolderViewListView::mouseDoubleClickEvent(QMouseEvent* event) {
     activationAllowed_ = activationWasAllowed;
 }
 
+QModelIndex FolderViewListView::moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) {
+    QAbstractItemModel* model_ = model();
+
+    if(model_ && currentIndex().isValid()) {
+        FolderView::ViewMode viewMode = static_cast<FolderView*>(parent())->viewMode();
+        if((viewMode == FolderView::IconMode) || (viewMode == FolderView::ThumbnailMode)) {
+            int next = (layoutDirection() == Qt::RightToLeft) ? - 1 : 1;
+
+            if(cursorAction == QAbstractItemView::MoveRight) {
+                return model_->index(currentIndex().row() + next, 0);
+            }
+            else if(cursorAction == QAbstractItemView::MoveLeft) {
+                return model_->index(currentIndex().row() - next, 0);
+            }
+        }
+    }
+
+    return QListView::moveCursor(cursorAction, modifiers);
+}
+
 void FolderViewListView::activation(const QModelIndex& index) {
     if(activationAllowed_) {
         Q_EMIT activatedFiltered(index);

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -63,6 +63,9 @@ public:
 Q_SIGNALS:
   void activatedFiltered(const QModelIndex &index);
 
+protected:
+  virtual QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers);
+
 private Q_SLOTS:
   void activation(const QModelIndex &index);
 


### PR DESCRIPTION
In folder view when left/right arrow key is pressed and current item is first/last on the row, selection continues on previous/next row accordingly.

Before this patch, selection stopped on the current row.

****
First, I'm not sure if it's done correctly, tell me if not.

Runtime check for current view mode is there because in "Compact View" left/right arrow keys are used differently.

Checks for first and last items overflow/underflow are done in FolderModel class, so not needed here.


This behaviour was missing at least to me, and is standard in pcmanfm(gtk), thunar and win explorer too.
