### PR TITLE
Ensure one item per file

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -463,11 +463,29 @@ void Folder::onDirListFinished() {
     }
     dirInfo_ = job->dirInfo();
 
-    auto& files_to_add = job->files();
-    for(auto& file: files_to_add) {
-        files_[file->name()] = file;
+    FileInfoList files_to_add;
+    std::vector<FileInfoPair> files_to_update;
+
+    const auto& infos = job->files();
+    auto info_it = infos.cbegin();
+    for(; info_it != infos.cend(); ++info_it) {
+        const auto& info = *info_it;
+        auto it = files_.find(info->name());
+        if(it != files_.end()) {
+            files_to_update.push_back(std::make_pair(it->second, info));
+        }
+        else {
+            files_to_add.push_back(info);
+        }
+        files_[info->name()] = info;
     }
-    Q_EMIT filesAdded(files_to_add);
+
+    if(!files_to_add.empty()) {
+        Q_EMIT filesAdded(files_to_add);
+    }
+    if(!files_to_update.empty()) {
+        Q_EMIT filesChanged(files_to_update);
+    }
 
 #if 0
     if(dirlist_job->isCancelled() && !wants_incremental) {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/482.

When the directory list job is finished on loading a folder, the list may contain more than one info per file because files may have been updated meanwhile (SFTP can be an example). In such cases, `filesChanged()` should be emitted instead of `filesAdded()`, otherwise more than one item will be shown for each file. In other words, infos should always be checked for being either added or updated.

Such cases were handled (and described as "very rare") by `libfm` but forgotten in the new `libfm-qt`.