### PR TITLE
Fix broken folder unmount message caused by incorrect FilePath & GFile* comparison.

### DIFF
--- a/src/core/filepath.h
+++ b/src/core/filepath.h
@@ -130,11 +130,15 @@ public:
     }
 
     bool operator == (const FilePath& other) const {
-        if(gfile_ == other.gfile_) {
+        return operator==(other.gfile_.get());
+    }
+
+    bool operator == (GFile* other_gfile) const {
+        if(gfile_ == other_gfile) {
             return true;
         }
-        if(gfile_ && other.gfile_) {
-            return g_file_equal(gfile_.get(), other.gfile_.get());
+        if(gfile_ && other_gfile) {
+            return g_file_equal(gfile_.get(), other_gfile);
         }
         return false;
     }

--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -423,7 +423,7 @@ void Folder::onFileChangeEvents(GFileMonitor* monitor, GFile* gf, GFile* other_f
         "G_FILE_MONITOR_EVENT_PRE_UNMOUNT",
         "G_FILE_MONITOR_EVENT_UNMOUNTED"
     }; */
-    if(dirPath_.gfile() == gf) {
+    if(dirPath_ == gf) {
         onDirChanged(evt);
         return;
     }


### PR DESCRIPTION
Add operator== for comparing FilePath and GFile* using g_file_equal() gio API.
This fixes the incorrect GFile* pointer comparison that caused broken folder unmount event.