### PR TITLE
Grey out files that have been Ctrl-X'ed

### DIFF
--- a/src/core/dirlistjob.cpp
+++ b/src/core/dirlistjob.cpp
@@ -6,7 +6,8 @@
 
 namespace Fm {
 
-DirListJob::DirListJob(const FilePath& path, Flags _flags): dir_path{path}, flags{_flags} {
+DirListJob::DirListJob(const FilePath& path, Flags _flags, const std::shared_ptr<const HashSet>& cutFilesHashSet):
+    dir_path{path}, flags{_flags}, cutFilesHashSet_{cutFilesHashSet} {
 }
 
 void DirListJob::exec() {
@@ -102,6 +103,12 @@ _retry:
                 if(emit_files_found) {
                     // Q_EMIT filesFound();
                 }
+
+                if(cutFilesHashSet_
+                        && cutFilesHashSet_->count(fileInfo->path().hash()) > 0) {
+                    fileInfo->bindCutFiles(cutFilesHashSet_);
+                }
+
                 foundFiles.push_back(std::move(fileInfo));
             }
             else {

--- a/src/core/dirlistjob.h
+++ b/src/core/dirlistjob.h
@@ -19,7 +19,7 @@ public:
         DETAILED = 1 << 1
     };
 
-    explicit DirListJob(const FilePath& path, Flags flags);
+    explicit DirListJob(const FilePath& path, Flags flags, const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
 
     FileInfoList& files() {
         return files_;
@@ -54,6 +54,7 @@ private:
     Flags flags;
     std::shared_ptr<const FileInfo> dir_fi;
     FileInfoList files_;
+    const std::shared_ptr<const HashSet> cutFilesHashSet_;
     bool emit_files_found;
     // guint delay_add_files_handler;
     // GSList* files_to_add;

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -287,6 +287,10 @@ _file_is_symlink:
 #endif
 }
 
+void FileInfo::bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet) {
+    cutFilesHashSet_ = cutFilesHashSet;
+}
+
 bool FileInfo::canThumbnail() const {
     /* We cannot use S_ISREG here as this exclude all symlinks */
     if(size_ == 0 ||  /* don't generate thumbnails for empty files */

--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -31,6 +31,7 @@
 #include <fcntl.h>
 
 #include <vector>
+#include <set>
 #include <utility>
 #include <string>
 #include <forward_list>
@@ -42,6 +43,9 @@
 
 
 namespace Fm {
+
+class FileInfoList;
+typedef std::set<unsigned int> HashSet;
 
 class LIBFM_QT_API FileInfo {
 public:
@@ -158,6 +162,10 @@ public:
         return dirPath_ ? dirPath_.isNative() : path().isNative();
     }
 
+    bool isCut() const {
+        return !cutFilesHashSet_.expired();
+    }
+
     mode_t mode() const {
         return mode_;
     }
@@ -187,6 +195,8 @@ public:
     }
 
     void setFromGFileInfo(const GFileInfoPtr& inf, const FilePath& parentDirPath);
+
+    void bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
 
     const std::forward_list<std::shared_ptr<const IconInfo>>& emblems() const {
         return emblems_;
@@ -225,6 +235,7 @@ private:
     bool isHiddenChangeable_ : 1; /* TRUE if hidden can be changed */
     bool isReadOnly_ : 1; /* TRUE if host FS is R/O */
 
+    std::weak_ptr<const HashSet> cutFilesHashSet_;
     // std::vector<std::tuple<int, void*, void(void*)>> extraData_;
 };
 

--- a/src/core/fileinfojob.h
+++ b/src/core/fileinfojob.h
@@ -13,7 +13,7 @@ class LIBFM_QT_API FileInfoJob : public Job {
     Q_OBJECT
 public:
 
-    explicit FileInfoJob(FilePathList paths, FilePath commonDirPath = FilePath());
+    explicit FileInfoJob(FilePathList paths, FilePath commonDirPath = FilePath(), const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
 
     const FilePathList& paths() const {
         return paths_;
@@ -33,6 +33,7 @@ private:
     FilePathList paths_;
     FileInfoList results_;
     FilePath commonDirPath_;
+    const std::shared_ptr<const HashSet> cutFilesHashSet_;
 };
 
 } // namespace Fm

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -80,6 +80,12 @@ public:
 
     const std::shared_ptr<const FileInfo> &info() const;
 
+    bool hadCutFilesUnset();
+
+    bool hasCutFiles();
+
+    void setCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
+
     void forEachFile(std::function<void (const std::shared_ptr<const FileInfo>&)> func) const {
         std::lock_guard<std::mutex> lock{mutex_};
         for(auto it = files_.begin(); it != files_.end(); ++it) {
@@ -179,6 +185,9 @@ private:
     bool defer_content_test : 1;
 
     static std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> cache_;
+    static FilePath cutFilesDirPath_;
+    static FilePath lastCutFilesDirPath_;
+    static std::shared_ptr<const HashSet> cutFilesHashSet_;
     static std::mutex mutex_;
 };
 

--- a/src/core/iconinfo.cpp
+++ b/src/core/iconinfo.cpp
@@ -57,16 +57,28 @@ void IconInfo::updateQIcons() {
     }
 }
 
-QIcon IconInfo::qicon() const {
-    if(Q_UNLIKELY(qicon_.isNull() && gicon_)) {
-        if(!G_IS_FILE_ICON(gicon_.get())) {
-            qicon_ = QIcon(new IconEngine{shared_from_this()});
-        }
-        else {
-            qicon_ = internalQicon_;
+QIcon IconInfo::qicon(const bool& transparent) const {
+    if(Q_LIKELY(!transparent)) {
+        if(Q_UNLIKELY(qicon_.isNull() && gicon_)) {
+            if(!G_IS_FILE_ICON(gicon_.get())) {
+                qicon_ = QIcon(new IconEngine{shared_from_this()});
+            }
+            else {
+                qicon_ = internalQicon_;
+            }
         }
     }
-    return qicon_;
+    else { // transparent == true
+        if(Q_UNLIKELY(qiconTransparent_.isNull() && gicon_)) {
+            if(!G_IS_FILE_ICON(gicon_.get())) {
+                qiconTransparent_ = QIcon(new IconEngine{shared_from_this(), transparent});
+            }
+            else {
+                qiconTransparent_ = internalQicon_;
+            }
+        }
+    }
+    return !transparent ? qicon_ : qiconTransparent_;
 }
 
 QIcon IconInfo::qiconFromNames(const char* const* names) {

--- a/src/core/iconinfo.h
+++ b/src/core/iconinfo.h
@@ -63,7 +63,7 @@ public:
         return gicon_;
     }
 
-    QIcon qicon() const;
+    QIcon qicon(const bool& transparent = false) const;
 
     bool hasEmblems() const {
         return G_IS_EMBLEMED_ICON(gicon_.get());
@@ -97,6 +97,7 @@ private:
 private:
     GIconPtr gicon_;
     mutable QIcon qicon_;
+    mutable QIcon qiconTransparent_;
     mutable QIcon internalQicon_;
 
     static std::unordered_map<GIcon*, std::shared_ptr<IconInfo>, GIconHash, GIconEqual> cache_;

--- a/src/core/iconinfo_p.h
+++ b/src/core/iconinfo_p.h
@@ -21,6 +21,7 @@
 #define FM_ICONENGINE_H
 
 #include <QIconEngine>
+#include <QPainter>
 #include "../libfmqtglobals.h"
 #include "iconinfo.h"
 #include <gio/gio.h>
@@ -30,7 +31,7 @@ namespace Fm {
 class IconEngine: public QIconEngine {
 public:
 
-    IconEngine(std::shared_ptr<const Fm::IconInfo> info);
+    IconEngine(std::shared_ptr<const Fm::IconInfo> info, const bool& transparent = false);
 
     ~IconEngine();
 
@@ -54,9 +55,11 @@ public:
 
 private:
     std::weak_ptr<const Fm::IconInfo> info_;
+    bool transparent_;
 };
 
-IconEngine::IconEngine(std::shared_ptr<const IconInfo> info): info_{info} {
+IconEngine::IconEngine(std::shared_ptr<const IconInfo> info, const bool& transparent):
+    info_{info}, transparent_{transparent} {
 }
 
 IconEngine::~IconEngine() {
@@ -78,8 +81,16 @@ QString IconEngine::key() const {
 
 void IconEngine::paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) {
     auto info = info_.lock();
-    if (info)
+    if(info) {
+        if(transparent_) {
+            painter->save();
+            painter->setOpacity(0.45);
+        }
         info->internalQicon().paint(painter, rect, Qt::AlignCenter, mode, state);
+        if(transparent_) {
+            painter->restore();
+        }
+    }
 }
 
 QPixmap IconEngine::pixmap(const QSize& size, QIcon::Mode mode, QIcon::State state) {

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -129,7 +129,15 @@ void FolderItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
         QPixmap pixmap = opt.icon.pixmap(option.decorationSize, iconMode);
         // in case the pixmap is smaller than the requested size
         QSize margin = ((option.decorationSize - pixmap.size()) / 2).expandedTo(QSize(0, 0));
+        bool isCut = index.data(FolderModel::FileIsCutRole).toBool();
+        if(isCut) {
+            painter->save();
+            painter->setOpacity(0.45);
+        }
         painter->drawPixmap(iconPos + QPoint(margin.width(), margin.height()), pixmap);
+        if(isCut) {
+            painter->restore();
+        }
 
         // draw some emblems for the item if needed
         if(isSymlink) {

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -23,6 +23,7 @@
 
 #include "libfmqtglobals.h"
 #include <QAbstractListModel>
+#include <QItemSelection>
 #include <QIcon>
 #include <QImage>
 #include <libfm/fm.h>
@@ -43,7 +44,8 @@ public:
 
     enum Role {
         FileInfoRole = Qt::UserRole,
-        FileIsDirRole
+        FileIsDirRole,
+        FileIsCutRole
     };
 
     enum ColumnId {
@@ -90,6 +92,8 @@ public:
 
     void cacheThumbnails(int size);
     void releaseThumbnails(int size);
+
+    void setCutFiles(const QItemSelection& selection);
 
 Q_SIGNALS:
     void thumbnailLoaded(const QModelIndex& index, int size);

--- a/src/foldermodelitem.cpp
+++ b/src/foldermodelitem.cpp
@@ -20,6 +20,7 @@
 
 #include "foldermodelitem.h"
 #include <QDateTime>
+#include <QPainter>
 #include "utilities.h"
 #include "core/userinfocache.h"
 
@@ -71,20 +72,63 @@ const QString& FolderModelItem::displaySize() const {
     return dispSize_;
 }
 
+bool FolderModelItem::isCut() const {
+    return !cutFilesHashSet_.expired() || info->isCut();
+}
+
+void FolderModelItem::bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet) {
+    cutFilesHashSet_ = cutFilesHashSet;
+}
+
 // find thumbnail of the specified size
 // The returned thumbnail item is temporary and short-lived
 // If you need to use the struct later, copy it to your own struct to keep it.
-FolderModelItem::Thumbnail* FolderModelItem::findThumbnail(int size) {
+FolderModelItem::Thumbnail* FolderModelItem::findThumbnail(int size, bool transparent) {
     QVector<Thumbnail>::iterator it;
+    Thumbnail* transThumb = nullptr;
     for(it = thumbnails.begin(); it != thumbnails.end(); ++it) {
-        if(it->size == size) { // an image of the same size is found
-            return it;
+        if(it->size == size) {
+            if(it->status != ThumbnailLoaded) {
+                return it;
+            }
+            else { // it->status == ThumbnailLoaded
+                if(it->transparent == false && transparent == true
+                        && size < 48 /* (dirty) needed only for 'compact' and 'details list' view */ ) {
+                    transThumb = it; // save thumb to add transparency later
+                }
+                else {
+                    return it; // an image of the same size and transparency is found
+                }
+            }
         }
     }
-    if(it == thumbnails.end()) {
+    if(transThumb) {
+        QImage image(transThumb->image);
+
+        if(!image.hasAlphaChannel()) {
+            image = image.convertToFormat(QImage::Format_ARGB32);
+        }
+
+        // add transparency to image
+        QPainter p;
+        p.begin(&image);
+        p.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+        p.fillRect(image.rect(), QColor(0, 0, 0, 115 /* alpha 45% */));
+        p.end();
+
+        // add image to thumbnails
+        Thumbnail thumbnail;
+        thumbnail.status = ThumbnailLoaded;
+        thumbnail.image = image;
+        thumbnail.size = size;
+        thumbnail.transparent = true;
+        thumbnails.append(thumbnail);
+    }
+    else if(it == thumbnails.end()) {
         Thumbnail thumbnail;
         thumbnail.status = ThumbnailNotChecked;
         thumbnail.size = size;
+        thumbnail.transparent = false;
         thumbnails.append(thumbnail);
     }
     return &thumbnails.back();

--- a/src/foldermodelitem.h
+++ b/src/foldermodelitem.h
@@ -45,6 +45,7 @@ public:
 
     struct Thumbnail {
         int size;
+        bool transparent;
         ThumbnailStatus status;
         QImage image;
     };
@@ -58,9 +59,9 @@ public:
         return info->displayName();
     }
 
-    QIcon icon() const {
+    QIcon icon(bool transparent = false) const {
         const auto i = info->icon();
-        return i ? i->qicon() : QIcon{};
+        return i ? i->qicon(transparent) : QIcon{};
     }
 
     QString ownerName() const;
@@ -71,13 +72,18 @@ public:
 
     const QString &displaySize() const;
 
-    Thumbnail* findThumbnail(int size);
+    bool isCut() const;
+
+    void bindCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet);
+
+    Thumbnail* findThumbnail(int size, bool transparent);
 
     void removeThumbnail(int size);
 
     std::shared_ptr<const Fm::FileInfo> info;
     mutable QString dispMtime_;
     mutable QString dispSize_;
+    std::weak_ptr<const HashSet> cutFilesHashSet_;
     QVector<Thumbnail> thumbnails;
 };
 

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -29,9 +29,11 @@
 #include "filemenu.h"
 #include "foldermenu.h"
 #include "filelauncher.h"
+#include "utilities.h"
 #include <QTimer>
 #include <QDate>
 #include <QDebug>
+#include <QClipboard>
 #include <QMimeData>
 #include <QHoverEvent>
 #include <QApplication>
@@ -474,6 +476,7 @@ FolderView::FolderView(FolderView::ViewMode _mode, QWidget *parent):
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     connect(this, &FolderView::clicked, this, &FolderView::onFileClicked);
+    connect(QApplication::clipboard(), &QClipboard::dataChanged, this, &FolderView::onClipboardDataChange);
 }
 
 FolderView::~FolderView() {
@@ -1159,6 +1162,33 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
         if(menu) {
             menu->exec(QCursor::pos());
             delete menu;
+        }
+    }
+}
+
+void FolderView::onClipboardDataChange() {
+    if(model_) {
+        const QClipboard* clipboard = QApplication::clipboard();
+        const QMimeData* data = clipboard->mimeData();
+        Fm::FilePathList paths;
+        bool isCutSelection;
+        std::tie(paths, isCutSelection) = Fm::parseClipboardData(*data);
+        if(!folder()->path().hasUriScheme("search") // skip for search results
+           && isCutSelection
+           && Fm::isCurrentPidClipboardData(*data)) { // set cut files only with this app
+            auto cutDirPath = paths.size() > 0 ? paths[0].parent(): FilePath();
+            if(folder()->path() == cutDirPath) {
+                model_->setCutFiles(selectionModel()->selection());
+            }
+            else if(folder()->hadCutFilesUnset() || folder()->hasCutFiles()) {
+                model_->setCutFiles(QItemSelection());
+            }
+            return;
+        }
+
+        folder()->setCutFiles(std::make_shared<HashSet>()); // clean Folder::cutFilesHashSet_
+        if(folder()->hadCutFilesUnset()) {
+            model_->setCutFiles(QItemSelection()); // update indexes if there were cut files here
         }
     }
 }

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -154,6 +154,7 @@ public Q_SLOTS:
     void onItemActivated(QModelIndex index);
     void onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
     virtual void onFileClicked(int type, const std::shared_ptr<const Fm::FileInfo>& fileInfo);
+    void onClipboardDataChange();
 
 private Q_SLOTS:
     void onAutoSelectionTimeout();

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -184,6 +184,13 @@ std::shared_ptr<const FileInfo> ProxyFolderModel::fileInfoFromPath(const FilePat
     return fileInfoFromIndex(indexFromPath(path));
 }
 
+void ProxyFolderModel::setCutFiles(const QItemSelection& selection) {
+    FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
+    if(srcModel) {
+        srcModel->setCutFiles(mapSelectionToSource(selection));
+    }
+}
+
 void ProxyFolderModel::setShowThumbnails(bool show) {
     if(show != showThumbnails_) {
         showThumbnails_ = show;

--- a/src/proxyfoldermodel.h
+++ b/src/proxyfoldermodel.h
@@ -64,6 +64,8 @@ public:
 
     void setSortCaseSensitivity(Qt::CaseSensitivity cs);
 
+    void setCutFiles(const QItemSelection& selection);
+
     bool showThumbnails() {
         return showThumbnails_;
     }

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -23,10 +23,12 @@
 #include "libfmqtglobals.h"
 #include <QUrl>
 #include <QList>
+#include <QMimeData>
 #include <libfm/fm.h>
 #include <sys/types.h>
 
 #include <cstdint>
+#include <utility>
 
 #include "core/filepath.h"
 #include "core/fileinfo.h"
@@ -41,11 +43,15 @@ LIBFM_QT_API QByteArray pathListToUriList(const Fm::FilePathList& paths);
 
 LIBFM_QT_API Fm::FilePathList pathListFromQUrls(QList<QUrl> urls);
 
+LIBFM_QT_API std::pair<Fm::FilePathList, bool> parseClipboardData(const QMimeData& data);
+
 LIBFM_QT_API void pasteFilesFromClipboard(const Fm::FilePath& destPath, QWidget* parent = 0);
 
 LIBFM_QT_API void copyFilesToClipboard(const Fm::FilePathList& files);
 
 LIBFM_QT_API void cutFilesToClipboard(const Fm::FilePathList& files);
+
+LIBFM_QT_API bool isCurrentPidClipboardData(const QMimeData& data);
 
 LIBFM_QT_API void changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent);
 


### PR DESCRIPTION
Add visual feedback for files that have been 'cut' to clipboard.
---
Hello. Referring to [issue #503](https://github.com/lxde/pcmanfm-qt/issues/503).

I was looking on that and made some working draft. But before more work to be put into this I'd like to know if you think this is good way at all and if you are interested in it.

I put more details in source comments temporarily.

I can answer design decisions but mostly they were influenced by speed requirements (to the point I understood them as such).

This solution is based mostly on weak pointers serving as "observers" to current cut selection, and if present - adjusting icons transparency (icons/thumbnails view only now)

In this approach, two lines of code are necessary to add to *pcmanfm-qt* because actual CTRL-X key shortcut is defined and processed there - test it with mouse context menu -> "cut" for now.

If you see something very mysterious there, that's possible, this is my first meet with all this, smart pointers etc.

This is not a ready to commit PR yet but a designing proposal.
