### PR TITLE
folderview: Don't allow D&D by Back or Forward

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -70,6 +70,13 @@ void FolderViewListView::mousePressEvent(QMouseEvent* event) {
     static_cast<FolderView*>(parent())->childMousePressEvent(event);
 }
 
+void FolderViewListView::mouseMoveEvent(QMouseEvent* event) {
+    // NOTE: Filter the BACK & FORWARD buttons to not Drag & Drop with them.
+    // (by default Qt views drag with any button)
+    if (event->buttons() == Qt::NoButton || event->buttons() & ~(Qt::BackButton | Qt::ForwardButton))
+        QListView::mouseMoveEvent(event);
+}
+
 QModelIndex FolderViewListView::indexAt(const QPoint& point) const {
     QModelIndex index = QListView::indexAt(point);
     // NOTE: QListView has a severe design flaw here. It does hit-testing based on the
@@ -241,6 +248,13 @@ void FolderViewTreeView::setModel(QAbstractItemModel* model) {
 void FolderViewTreeView::mousePressEvent(QMouseEvent* event) {
     QTreeView::mousePressEvent(event);
     static_cast<FolderView*>(parent())->childMousePressEvent(event);
+}
+
+void FolderViewTreeView::mouseMoveEvent(QMouseEvent* event) {
+    // NOTE: Filter the BACK & FORWARD buttons to not Drag & Drop with them.
+    // (by default Qt views drag with any button)
+    if (event->buttons() == Qt::NoButton || event->buttons() & ~(Qt::BackButton | Qt::ForwardButton))
+        QTreeView::mouseMoveEvent(event);
 }
 
 void FolderViewTreeView::dragEnterEvent(QDragEnterEvent* event) {

--- a/src/folderview_p.h
+++ b/src/folderview_p.h
@@ -39,6 +39,7 @@ public:
   virtual ~FolderViewListView();
   virtual void startDrag(Qt::DropActions supportedActions);
   virtual void mousePressEvent(QMouseEvent* event);
+  virtual void mouseMoveEvent(QMouseEvent* event);
   virtual void mouseReleaseEvent(QMouseEvent* event);
   virtual void mouseDoubleClickEvent(QMouseEvent* event);
   virtual void dragEnterEvent(QDragEnterEvent* event);
@@ -81,6 +82,7 @@ public:
   virtual ~FolderViewTreeView();
   virtual void setModel(QAbstractItemModel* model);
   virtual void mousePressEvent(QMouseEvent* event);
+  virtual void mouseMoveEvent(QMouseEvent* event);
   virtual void mouseReleaseEvent(QMouseEvent* event);
   virtual void mouseDoubleClickEvent(QMouseEvent* event);
   virtual void dragEnterEvent(QDragEnterEvent* event);


### PR DESCRIPTION
By default Qt allows D&D by any mouse button.

fixes lxde/pcmanfm-qt#486