### PR TITLE
MountOperationQuestionDialog: Fix handling responses

### DIFF
--- a/src/mountoperationquestiondialog_p.h
+++ b/src/mountoperationquestiondialog_p.h
@@ -22,6 +22,7 @@
 #define FM_MOUNTOPERATIONQUESTIONDIALOG_H
 
 #include "libfmqtglobals.h"
+#include <QCloseEvent>
 #include <QMessageBox>
 #include <gio/gio.h>
 
@@ -36,9 +37,7 @@ public:
     virtual ~MountOperationQuestionDialog();
 
     virtual void done(int r);
-
-private Q_SLOTS:
-    void onButtonClicked(QAbstractButton* button);
+    virtual void closeEvent(QCloseEvent *event);
 
 private:
     MountOperation* mountOperation;


### PR DESCRIPTION
Remove check for 'if(r != QDialog::Accepted)' because
all buttons have 'QMessageBox::AcceptRole' set.

Implement close event to process click on title bar's X button.

----
ref. issue [#519](https://github.com/lxde/pcmanfm-qt/issues/519)