### PR TITLE
Drops Qt5Core_VERSION_STRING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(MenuCache "${REQUIRED_LIBMENUCACHE_VERSION}" REQUIRED)
 find_package(Exif REQUIRED)
 find_package(XCB REQUIRED)
 
-message(STATUS "Building ${PROJECT_NAME} with Qt ${Qt5Core_VERSION_STRING}")
+message(STATUS "Building ${PROJECT_NAME} with Qt ${Qt5Core_VERSION}")
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 include(GNUInstallDirs)


### PR DESCRIPTION
Use Qt5Core_VERSION. Qt5Core_VERSION_STRING is a compatibility variable and
it was removed in Qt 5.9 release.