### PR TITLE
Inline Renaming

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -31,6 +31,7 @@
 #include "customaction_p.h"
 
 #include <QMessageBox>
+#include <QAbstractItemView>
 #include <QDebug>
 #include "filemenu_p.h"
 
@@ -328,6 +329,13 @@ void FileMenu::onPasteTriggered() {
 }
 
 void FileMenu::onRenameTriggered() {
+    if (QAbstractItemView* view = qobject_cast<QAbstractItemView*>(parentWidget())) {
+        // if there is a view and this is a single file, just edit the current index
+        if (view->currentIndex().isValid() && files_.size() == 1) {
+            view->edit(view->currentIndex());
+            return;
+        }
+    }
     for(auto& info: files_) {
         Fm::renameFile(info, nullptr);
     }

--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -314,6 +314,13 @@ QWidget* FolderItemDelegate::createEditor(QWidget* parent, const QStyleOptionVie
         // because the latter always shows an empty space at the bottom)
         QTextEdit *textEdit = new QTextEdit(parent);
         textEdit->setAcceptRichText(false);
+
+        // Since the text color on desktop is inherited from desktop foreground color,
+        // it may not be suitable. So, we reset it by using the app palette.
+        QPalette p = textEdit->palette();
+        p.setColor(QPalette::Text, qApp->palette().text().color());
+        textEdit->setPalette(p);
+
         textEdit->ensureCursorVisible();
         textEdit->setFocusPolicy(Qt::StrongFocus);
         textEdit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -85,9 +85,21 @@ public:
       return margins_;
     }
 
+    bool hasEditor() const {
+        return hasEditor_;
+    }
+
     virtual QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const;
 
     virtual void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+
+    virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+
+    virtual void setEditorData(QWidget* editor, const QModelIndex& index) const;
+
+    virtual bool eventFilter(QObject* object, QEvent* event);
+
+    virtual void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const;
 
     QSize iconViewTextSize(const QModelIndex& index) const;
 
@@ -104,6 +116,7 @@ private:
     int iconInfoRole_;
     QColor shadowColor_;
     QSize margins_;
+    mutable bool hasEditor_;
 };
 
 }

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -211,6 +211,7 @@ QVariant FolderModel::data(const QModelIndex& index, int role/* = Qt::DisplayRol
         case ColumnFileOwner:
             return item->ownerName();
         }
+        break;
     }
     case Qt::DecorationRole: {
         if(index.column() == 0) {
@@ -218,8 +219,16 @@ QVariant FolderModel::data(const QModelIndex& index, int role/* = Qt::DisplayRol
         }
         break;
     }
+    case Qt::EditRole: {
+        if(index.column() == 0) {
+            return QString::fromStdString(info->name());
+        }
+        break;
+    }
     case FileInfoRole:
         return QVariant::fromValue(info);
+    case FileIsDirRole:
+        return QVariant(info->isDir());
     }
     return QVariant();
 }
@@ -269,7 +278,8 @@ Qt::ItemFlags FolderModel::flags(const QModelIndex& index) const {
     if(index.isValid()) {
         flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
         if(index.column() == ColumnFileName) {
-            flags |= (Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled);
+            flags |= (Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled
+                      | Qt::ItemIsEditable); // inline renaming);
         }
     }
     else {

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -42,7 +42,8 @@ class LIBFM_QT_API FolderModel : public QAbstractListModel {
 public:
 
     enum Role {
-        FileInfoRole = Qt::UserRole
+        FileInfoRole = Qt::UserRole,
+        FileIsDirRole
     };
 
     enum ColumnId {

--- a/src/folderview.h
+++ b/src/folderview.h
@@ -155,6 +155,7 @@ public Q_SLOTS:
 private Q_SLOTS:
     void onAutoSelectionTimeout();
     void onSelChangedTimeout();
+    void onClosingEditor(QWidget* editor, QAbstractItemDelegate::EndEditHint hint);
 
 Q_SIGNALS:
     void clicked(int type, const std::shared_ptr<const Fm::FileInfo>& file);

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -48,6 +48,8 @@ LIBFM_QT_API void copyFilesToClipboard(const Fm::FilePathList& files);
 
 LIBFM_QT_API void cutFilesToClipboard(const Fm::FilePathList& files);
 
+LIBFM_QT_API void changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent);
+
 LIBFM_QT_API void renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = 0);
 
 enum CreateFileType {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/468 by implementing inline renaming for the icon, thumbnail and compact views (the detailed list view needs a separate handling).

Inline renaming of the current item is started by the context menu-item `Rename` or `F2` when only one file/folder is selected. It is finished by Enter/Return or by removing focus from the item, and canceled by Esc. If several items are selected, renaming will be done as before, i.e. by calling the rename dialog.

For user convenience, wheel scrolling is disabled for the folder view during inline renaming.

Another PR for desktop is not needed after recent changes in libfm-qt but a pcmanfm-qt PR for `F2` will follow this.

A screenshot for icon and compact views:
![inline_renaming](https://user-images.githubusercontent.com/981076/27973721-47de3736-6370-11e7-895c-9d4cd7950a74.png)
