### PR TITLE
Avoid using grid size of QListView so we can have margins in the folder views.

### DIFF
--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -23,7 +23,7 @@
 
 #include "libfmqtglobals.h"
 #include <QStyledItemDelegate>
-#include <QAbstractItemView>
+class QAbstractItemView;
 
 namespace Fm {
 
@@ -31,14 +31,23 @@ class LIBFM_QT_API FolderItemDelegate : public QStyledItemDelegate {
     Q_OBJECT
 public:
     explicit FolderItemDelegate(QAbstractItemView* view, QObject* parent = nullptr);
+
     virtual ~FolderItemDelegate();
 
-    inline void setGridSize(QSize size) {
-        gridSize_ = size;
+    inline void setItemSize(QSize size) {
+        itemSize_ = size;
     }
 
-    inline QSize gridSize() const {
-        return gridSize_;
+    inline QSize itemSize() const {
+        return itemSize_;
+    }
+
+    inline void setIconSize(QSize size) {
+        iconSize_ = size;
+    }
+
+    inline QSize iconSize() const {
+        return iconSize_;
     }
 
     int fileInfoRole() {
@@ -58,16 +67,18 @@ public:
     }
 
     virtual QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const;
+
     virtual void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
 
 private:
     void drawText(QPainter* painter, QStyleOptionViewItem& opt, QRectF& textRect) const;
+
     static QIcon::Mode iconModeFromState(QStyle::State state);
 
 private:
-    QAbstractItemView* view_;
     QIcon symlinkIcon_;
-    QSize gridSize_;
+    QSize iconSize_;
+    QSize itemSize_;
     int fileInfoRole_;
     int iconInfoRole_;
 };

--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -66,6 +66,21 @@ public:
         iconInfoRole_ = role;
     }
 
+    // only support vertical layout (icon view mode: text below icon)
+    void setShadowColor(const QColor& shadowColor) {
+      shadowColor_ = shadowColor;
+    }
+
+    // only support vertical layout (icon view mode: text below icon)
+    const QColor& shadowColor() const {
+      return shadowColor_;
+    }
+
+    // only support vertical layout (icon view mode: text below icon)
+    void setMargins(QSize margins) {
+      margins_ = margins.expandedTo(QSize(0, 0));
+    }
+
     virtual QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const;
 
     virtual void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
@@ -81,6 +96,8 @@ private:
     QSize itemSize_;
     int fileInfoRole_;
     int iconInfoRole_;
+    QColor shadowColor_;
+    QSize margins_;
 };
 
 }

--- a/src/folderitemdelegate.h
+++ b/src/folderitemdelegate.h
@@ -81,9 +81,15 @@ public:
       margins_ = margins.expandedTo(QSize(0, 0));
     }
 
+    QSize getMargins() const {
+      return margins_;
+    }
+
     virtual QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const;
 
     virtual void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+
+    QSize iconViewTextSize(const QModelIndex& index) const;
 
 private:
     void drawText(QPainter* painter, QStyleOptionViewItem& opt, QRectF& textRect) const;

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -93,7 +93,8 @@ QModelIndex FolderViewListView::indexAt(const QPoint& point) const {
         // We use the grid size - (2, 2) as the size of the bounding rectangle of the whole item.
         // The width of the text label hence is gridSize.width - 2, and the width and height of the icon is from iconSize().
         QRect visRect = visualRect(index); // visibal area on the screen
-        QSize itemSize = gridSize();
+        auto delegate = itemDelegateForColumn(FolderModel::ColumnFileName);
+        QSize itemSize = static_cast<FolderItemDelegate*>(delegate)->itemSize();
         itemSize.setWidth(itemSize.width() - 2);
         itemSize.setHeight(itemSize.height() - 2);
         QSize _iconSize = iconSize();
@@ -630,19 +631,20 @@ void FolderView::updateGridSize() {
         int textHeight = fm.lineSpacing() * 3;
         grid.setWidth(qMax(icon.width(), textWidth) + 4); // a margin of 2 px for selection rects
         grid.setHeight(icon.height() + textHeight + 4); // a margin of 2 px for selection rects
+
+        listView->setSpacing(24);    // the default spacing is 6(=2x3) px
         break;
     }
     default:
+        // FIXME: set proper item size
+        listView->setSpacing(2);    // the default spacing is 6(=2x3) px
         ; // do not use grid size
     }
-    if(mode == IconMode || mode == ThumbnailMode) {
-        listView->setGridSize(grid + 2 * itemDelegateMargins_);    // the default spacing is 6(=2x3) px
-    }
-    else {
-        listView->setGridSize(grid);
-    }
+    listView->setUniformItemSizes(true);
+
     FolderItemDelegate* delegate = static_cast<FolderItemDelegate*>(listView->itemDelegateForColumn(FolderModel::ColumnFileName));
-    delegate->setGridSize(grid);
+    delegate->setItemSize(grid);
+    delegate->setIconSize(icon);
 }
 
 void FolderView::setIconSize(ViewMode mode, QSize size) {

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -951,15 +951,6 @@ bool FolderView::eventFilter(QObject* watched, QEvent* event) {
     if(view && watched == view->viewport()) {
         switch(event->type()) {
         case QEvent::HoverMove:
-            /*if (view && mode != DetailedListMode) {
-                FolderViewListView* listView = static_cast<FolderViewListView*>(view);
-                FolderItemDelegate* delegate = static_cast<FolderItemDelegate*>(listView->itemDelegateForColumn(FolderModel::ColumnFileName));
-                QHoverEvent* hoverEvent = static_cast<QHoverEvent*>(event);
-                QModelIndex index = view->indexAt(hoverEvent->pos());
-                if (index.isValid() && !static_cast<FolderItemDelegate*>(delegate)->itemRegion(index).contains(hoverEvent->pos()))
-                    setCursor(Qt::ArrowCursor);
-                    break;
-            }*/
             // activate items on single click
             if(style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick)) {
                 QHoverEvent* hoverEvent = static_cast<QHoverEvent*>(event);


### PR DESCRIPTION
Because we use "grid size" of QListView to enforce uniform icon size and better icon layout, we lost proper margins since the QListView "icon spacing" settings cannot be used along with "grid size". So the folder view of pcmanfm-qt looks pretty ugly for years.

Before the PR:
![folder_view_no_margins](https://user-images.githubusercontent.com/46543/27995245-7023d776-64fd-11e7-97c2-08d152890f0c.png)

Finally I figured out how to do it properly with QListView.
After the PR:
![folder_view_margins](https://user-images.githubusercontent.com/46543/27995167-88fe60a0-64fc-11e7-97b4-e2848c13c48b.png)

There are still some glitch and the spacing settings still requires some tuning, I think it looks much nicer now.

Also, this PR moves the text shadow painting code from PCManFM::DesktopItemDelegate to Fm::FolderItemDelegate. So pcmanfm-qt can reuse the class directly without adding its own item delegate.
https://github.com/lxde/pcmanfm-qt/pull/529