### PR TITLE
Fix major bugs in Directory Tree

### DIFF
--- a/src/dirtreemodelitem.h
+++ b/src/dirtreemodelitem.h
@@ -52,6 +52,11 @@ public:
 
     void setShowHidden(bool show);
 
+    bool isQueuedForDeletion() {
+        return queuedForDeletion_;
+    }
+    
+
 private:
     void freeFolder();
     void addPlaceHolderChild();
@@ -76,10 +81,12 @@ private:
     bool expanded_;
     bool loaded_;
     DirTreeModelItem* parent_;
+    bool deleteLater_;
     DirTreeModelItem* placeHolderChild_;
     std::vector<DirTreeModelItem*> children_;
     std::vector<DirTreeModelItem*> hiddenChildren_;
     DirTreeModel* model_;
+    bool queuedForDeletion_;
     // signal connections
     QMetaObject::Connection onFolderFinishLoadingConn_;
     QMetaObject::Connection onFolderFilesAddedConn_;

--- a/src/dirtreemodelitem.h
+++ b/src/dirtreemodelitem.h
@@ -81,7 +81,6 @@ private:
     bool expanded_;
     bool loaded_;
     DirTreeModelItem* parent_;
-    bool deleteLater_;
     DirTreeModelItem* placeHolderChild_;
     std::vector<DirTreeModelItem*> children_;
     std::vector<DirTreeModelItem*> hiddenChildren_;

--- a/src/dirtreeview.h
+++ b/src/dirtreeview.h
@@ -54,6 +54,7 @@ public:
 
 protected:
     virtual void mousePressEvent(QMouseEvent* event);
+    virtual void rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end);
 
 private:
     void cancelPendingChdir();
@@ -78,11 +79,14 @@ protected Q_SLOTS:
     void onNewTab();
     void onOpenInTerminal();
     void onNewFolder();
+    void rowsRemoved(const QModelIndex& parent, int start, int end);
+    void doQueuedDeletions();
 
 private:
     Fm::FilePath currentPath_;
     Fm::FilePathList pathsToExpand_;
     DirTreeModelItem* currentExpandingItem_;
+    std::vector<DirTreeModelItem*> queuedForDeletion_;
 };
 
 }


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/532.

The following issues are fixed:

(1) Crash on using `Ctrl+H` when the tree is expanded.
(2) Crash on reloading when the tree is expanded.
(3) Freeze when an expanded (selected or non-selected) folder is removed.
(4) Non-folder files were shown by `Ctrl+H` sometimes.
(5) Empty items were shown by `Ctrl+H` sometimes.
(6) Sometimes irrelevant folders (nodes) were selected on removing folders or making them hidden.
(7) The hidden subfolders of an expanded folder weren't shown by `Ctrl+H` until the node collapsed and expanded again.

There are still other bugs, which I'm aware of but aren't as important as the above ones. They need separate PRs.

P.S. Please tell me if you succeed in making Directory Tree crash or freeze with this patch!