### PR TITLE
Fix compact view regression

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -651,7 +651,6 @@ void FolderView::updateGridSize() {
         listView->setSpacing(2);
         ; // do not use grid size
     }
-    listView->setUniformItemSizes(true);
 
     FolderItemDelegate* delegate = static_cast<FolderItemDelegate*>(listView->itemDelegateForColumn(FolderModel::ColumnFileName));
     delegate->setItemSize(grid);


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/537.

`uniformItemSizes` had side effects not only for compact view but also when set for icon view because compact view would be broken after switching to it from icon view. On the other hand, `uniformItemSizes` had no use for us because we set item sizes in icon view.