### PR TITLE
Support custom folder icons

### DIFF
--- a/src/filepropsdialog.h
+++ b/src/filepropsdialog.h
@@ -66,6 +66,7 @@ private:
 private Q_SLOTS:
     void onDeepCountJobFinished();
     void onFileSizeTimerTimeout();
+    void onIconButtonclicked();
 
 private:
     Ui::FilePropsDialog* ui;
@@ -75,6 +76,7 @@ private:
     bool singleFile; // only one file is selected?
     bool hasDir; // is there any dir in the files?
     bool allNative; // all files are on native UNIX filesystems (not virtual or remote)
+    QIcon customIcon; // custom (folder) icon (wiil be checked for its nullity)
 
     std::shared_ptr<const Fm::MimeType> mimeType; // mime type of the files
 


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/547.

This patch does two interrelated jobs:

(1) It reads the file ".directory" inside a (native) folder if it exists and sets the icon of that folder accordingly;

(2) It also activates the icon button of the properties dialog for setting a custom icon when the chosen files are all (native) directories. The parent folder will be automatically reloaded on clicking `OK` if a (different) custom icon is selected.

NOTES:

● To test it, you could click on the icon button of the properties dialog of a folder or multiple folders; then, a dialog will pop up, showing the active icon theme folder for selecting a custom icon.

● I couldn't find any tangible difference, with and without applying this patch, in the time needed to load a directory with ~340 folders after a cold boot.

● If approved, another patch will follow this to set bookmark icons accordingly, so that their icons be identical to their corresponding folders.