### PR TITLE
Check nullity of FileInfo before calling FolderMenu

### DIFF
--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -73,17 +73,20 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
     connect(showHiddenAction_, &QAction::triggered, this, &FolderMenu::onShowHiddenActionTriggered);
 
     // DES-EMA custom actions integration
-    FileInfoList files;
-    files.push_back(view->folderInfo());
-    auto custom_actions = FileActionItem::get_actions_for_files(files);
-    for(auto& item: custom_actions) {
-        if(item && !(item->get_target() & FILE_ACTION_TARGET_CONTEXT)) {
-            continue;  // this item is not for context menu
+    auto folderInfo = view_->folderInfo();
+    if(folderInfo) { // should never be null (see FolderView::onFileClicked)
+        FileInfoList files;
+        files.push_back(folderInfo);
+        auto custom_actions = FileActionItem::get_actions_for_files(files);
+        for(auto& item: custom_actions) {
+            if(item && !(item->get_target() & FILE_ACTION_TARGET_CONTEXT)) {
+                continue;  // this item is not for context menu
+            }
+            if(item == custom_actions.front() && item && !item->is_action()) {
+                addSeparator(); // before all custom actions
+            }
+            addCustomActionItem(this, item);
         }
-        if(item == custom_actions.front() && item && !item->is_action()) {
-            addSeparator(); // before all custom actions
-        }
-        addCustomActionItem(this, item);
     }
 
     separator4_ = addSeparator();

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1151,7 +1151,7 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
                 menu = fileMenu;
             }
         }
-        else {
+        else if (folderInfo()) {
             Fm::FolderMenu* folderMenu = new Fm::FolderMenu(this);
             prepareFolderMenu(folderMenu);
             menu = folderMenu;


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/540.

(I guess the probability of a crash was higher with sshd.)