### PR TITLE
Arrange Custom Actions

### DIFF
--- a/src/customactions/fileaction.h
+++ b/src/customactions/fileaction.h
@@ -137,6 +137,7 @@ public:
         return children;
     }
 
+    static bool compare_items(std::shared_ptr<const FileActionItem> a, std::shared_ptr<const FileActionItem> b);
     static std::vector<std::shared_ptr<const FileActionItem>> get_actions_for_files(const FileInfoList& files);
 
     std::string name;


### PR DESCRIPTION
Fixes from https://github.com/lxde/pcmanfm-qt/issues/438 → "Issue 2"

Arranges custom actions according to the standard explained at http://www.nautilus-actions.org/?q=node/377.

The items that are included in `~/.local/share/file-manager/actions/level-zero.directory` come first and in the order specified in that file. Other items follow them in the alphabetical order.

NOTE: The patch is logically very simple: a comparison function does the job.