### PR TITLE
Check nullity of QMimeData

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -377,7 +377,7 @@ QMimeData* FolderModel::mimeData(const QModelIndexList& indexes) const {
 
 bool FolderModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) {
     qDebug("FolderModel::dropMimeData");
-    if(!folder_) {
+    if(!folder_ || !data) {
         return false;
     }
     Fm::FilePath destPath;


### PR DESCRIPTION
This is done in `QAbstractItemModel::dropMimeData()` and should be done here too.

NOTE: Without this, I encountered a very rare (and unreproducible) crash, whose backtrace started with:
```
0  0x00007fbd1da1464d in QMimeData::hasUrls() const () at /usr/lib/libQt5Core.so.5
1  0x00007fbd1f0ec4e2 in  () at /usr/lib/libfm-qt.so.3
```