### PR TITLE
Ignore button for error dialog

### DIFF
--- a/src/fileoperationdialog.h
+++ b/src/fileoperationdialog.h
@@ -58,6 +58,7 @@ private:
     Ui::FileOperationDialog* ui;
     FileOperation* operation;
     int defaultOption;
+    bool ignoreNonCriticalErrors_;
 };
 
 }


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/512.

When the error is not serious, an ignore button is added to the error dialog. If the user presses it instead of `OK`, the operation will be continued without showing another dialog for a non-critical error.

To test (as @fulalas [proposed](https://github.com/lxde/pcmanfm-qt/issues/512#issuecomment-312261245)):

(1) Enable "Confirm before moving files into trash can" in Preferences;
(2) Create a folder and multiple files int it;
(3) Select all of those files and try to move them to trash but do NOT confirm yet;
(4) Delete those files within a terminal;
(5) Confirm moving to trash now.