### PR TITLE
Initialize FileInfo::isShortcut_

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -107,6 +107,8 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
         goto _file_is_symlink;
     }
 
+    isShortcut_ = false;
+
     switch(type) {
     case G_FILE_TYPE_SHORTCUT:
         isShortcut_ = true;


### PR DESCRIPTION
It was left uninitialized. I encountered a strange problem while fixing https://github.com/lxde/libfm-qt/pull/112 and found that this was the cause. Luckily, it wasn't able to create a serious problem in the only place it was used, namely, desktop.