### PR TITLE
Respect inactiveness when drawing text

### DIFF
--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -242,7 +242,11 @@ void FolderItemDelegate::drawText(QPainter* painter, QStyleOptionViewItem& opt, 
     }
 
     // ?????
-    QPalette::ColorGroup cg = (opt.state & QStyle::State_Enabled) ? QPalette::Normal : QPalette::Disabled;
+    QPalette::ColorGroup cg = (opt.state & QStyle::State_Enabled)
+                                  ? (opt.state & QStyle::State_Active)
+                                      ? QPalette::Active
+                                      : QPalette::Inactive
+                                  : QPalette::Disabled;
     if(opt.state & QStyle::State_Selected) {
         if(!opt.widget) {
             painter->fillRect(selRect, opt.palette.highlight());


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/560.

Previously, the text was always drawn with the active (normal) color group, even when the state was not active. This patch sets the correct color group for both normal and selected texts. Although the difference is only visible with Qt styles (like Kvantum) that handle inactiveness, the logic should be respected.