### PR TITLE
UI improvements for Fm::MountOperationPasswordDialog()

### DIFF
--- a/src/mountoperationpassworddialog.cpp
+++ b/src/mountoperationpassworddialog.cpp
@@ -46,11 +46,17 @@ MountOperationPasswordDialog::MountOperationPasswordDialog(MountOperation* op, G
     }
     else {
         ui->Anonymous->setEnabled(false);
+        ui->asUser->setChecked(true);
     }
     if(!needUserName) {
         ui->username->setEnabled(false);
     }
-    if(!needPassword) {
+    if(needPassword) {
+        if(!needUserName) {
+            ui->password->setFocus();
+        }
+    }
+    else {
         ui->password->setEnabled(false);
     }
     if(!needDomain) {


### PR DESCRIPTION
Check _Connect as user_ radio button automatically if anonymous
login is not available. Set focus to password field if username
was already entered (and field is disabled).

Setting auto focus to username field would be a dead code because
anonymous login is predefined and this field is then disabled at first anyway.

----

Before the patch we start with this window

![before](https://user-images.githubusercontent.com/25567234/30592895-f275361a-9d48-11e7-8f2e-0df803815c02.png)

After 

![after](https://user-images.githubusercontent.com/25567234/30592902-f80db444-9d48-11e7-831a-48f2484ad58d.png)


ref. to issue [#519](https://github.com/lxde/pcmanfm-qt/issues/519#issuecomment-312790321)

btw. if all two radio buttons (for anonymous and username login) are available, I vote _No_ for setting focus automatically to user name field when clicking on _Connect as user_ in this case. I tested it and didn't like it.