### PR TITLE
Fix partially visible toggled path buttons

### DIFF
--- a/src/pathbar.h
+++ b/src/pathbar.h
@@ -61,6 +61,7 @@ private Q_SLOTS:
   void onReturnPressed();
   void setArrowEnabledState(int value);
   void setScrollButtonVisibility();
+  void ensureToggledVisible();
 
 protected:
     void resizeEvent(QResizeEvent* event);


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/561

Sometimes, the toggled path button wasn't scrolled to correctly (in file dialog as well as in pcmanfm-qt) because the layout of the scroll-area was being updated simultaneously. The issue is fixed by using `QTimer::singleShot()` in a proper way.

Also compensated for a small miscalculation in Qt.