### PR TITLE
Disable context-menu actions that cannot be used

### DIFF
--- a/src/core/fileinfo.h
+++ b/src/core/fileinfo.h
@@ -115,6 +115,14 @@ public:
         return isAccessible_;
     }
 
+    bool isWritable() const {
+        return isWritable_;
+    }
+
+    bool isDeletable() const {
+        return isDeletable_;
+    }
+
     bool isExecutableType() const;
 
     bool isBackup() const {
@@ -228,6 +236,8 @@ private:
 
     bool isShortcut_ : 1; /* TRUE if file is shortcut type */
     bool isAccessible_ : 1; /* TRUE if can be read by user */
+    bool isWritable_ : 1; /* TRUE if can be written to by user */
+    bool isDeletable_ : 1; /* TRUE if can be deleted by user */
     bool isHidden_ : 1; /* TRUE if file is hidden */
     bool isBackup_ : 1; /* TRUE if file is backup */
     bool isNameChangeable_ : 1; /* TRUE if name can be changed */

--- a/src/filemenu.h
+++ b/src/filemenu.h
@@ -38,7 +38,7 @@ class LIBFM_QT_API FileMenu : public QMenu {
     Q_OBJECT
 
 public:
-    explicit FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> info, Fm::FilePath cwd, const QString& title = QString(), QWidget* parent = nullptr);
+    explicit FileMenu(Fm::FileInfoList files, std::shared_ptr<const Fm::FileInfo> info, Fm::FilePath cwd, bool isWritableDir = true, const QString& title = QString(), QWidget* parent = nullptr);
     ~FileMenu();
 
     bool useTrash() {

--- a/src/foldermenu.cpp
+++ b/src/foldermenu.cpp
@@ -72,9 +72,9 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
     showHiddenAction_->setChecked(model->showHidden());
     connect(showHiddenAction_, &QAction::triggered, this, &FolderMenu::onShowHiddenActionTriggered);
 
-    // DES-EMA custom actions integration
     auto folderInfo = view_->folderInfo();
     if(folderInfo) { // should never be null (see FolderView::onFileClicked)
+        // DES-EMA custom actions integration
         FileInfoList files;
         files.push_back(folderInfo);
         auto custom_actions = FileActionItem::get_actions_for_files(files);
@@ -87,6 +87,9 @@ FolderMenu::FolderMenu(FolderView* view, QWidget* parent):
             }
             addCustomActionItem(this, item);
         }
+
+        // disable paste acton if it can't be used
+        pasteAction_->setEnabled(folderInfo->isWritable());
     }
 
     separator4_ = addSeparator();

--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1157,15 +1157,20 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
     }
     else if(type == ContextMenuClick) {
         Fm::FilePath folderPath;
+        bool isWritableDir(true);
         auto files = selectedFiles();
         if(!files.empty()) {
             auto& first = files.front();
             if(files.size() == 1 && first->isDir()) {
                 folderPath = first->path();
+                isWritableDir = first->isWritable();
             }
         }
         if(!folderPath.isValid()) {
             folderPath = path();
+            if(auto info = folderInfo()) {
+                isWritableDir = info->isWritable();
+            }
         }
         QMenu* menu = nullptr;
         if(fileInfo) {
@@ -1174,8 +1179,8 @@ void FolderView::onFileClicked(int type, const std::shared_ptr<const Fm::FileInf
             if(!files.empty()) {
                 QModelIndexList selIndexes = mode == DetailedListMode ? selectedRows() : selectedIndexes();
                 Fm::FileMenu* fileMenu = (view && selIndexes.size() == 1)
-                                         ? new Fm::FileMenu(files, fileInfo, folderPath, QString(), view)
-                                         : new Fm::FileMenu(files, fileInfo, folderPath);
+                                         ? new Fm::FileMenu(files, fileInfo, folderPath, isWritableDir, QString(), view)
+                                         : new Fm::FileMenu(files, fileInfo, folderPath, isWritableDir);
                 fileMenu->setFileLauncher(fileLauncher_);
                 prepareFileMenu(fileMenu);
                 menu = fileMenu;


### PR DESCRIPTION
Disable file actions that cannot be performed (ref. to https://github.com/lxde/pcmanfm-qt/issues/567).

IMO, all advanced file managers should have this feature. It prevents showing unnecessary error dialogs and serves as a kind of visual feedback about the nature of files/folders.

A pcmanfm-qt PR will follow this for disabling unperformable menubar Edit actions.