### PR TITLE
Add data transferred to file operation dialog.

### DIFF
--- a/src/file-operation-dialog.ui
+++ b/src/file-operation-dialog.ui
@@ -83,7 +83,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="label_5">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -96,7 +96,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QLabel" name="timeRemaining">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -116,6 +116,20 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Data transferred:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="dataTransferred">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>

--- a/src/fileoperation.cpp
+++ b/src/fileoperation.cpp
@@ -180,9 +180,10 @@ void FileOperation::onFileOpsJobFinished(FmFileOpsJob* /*job*/, FileOperation* p
     pThis->handleFinish();
 }
 
-void FileOperation::onFileOpsJobPercent(FmFileOpsJob* /*job*/, guint percent, FileOperation* pThis) {
+void FileOperation::onFileOpsJobPercent(FmFileOpsJob* job, guint percent, FileOperation* pThis) {
     if(pThis->dlg) {
         pThis->dlg->setPercent(percent);
+        pThis->dlg->setDataTransferred(job->finished, job->total);
     }
 }
 

--- a/src/fileoperationdialog.cpp
+++ b/src/fileoperationdialog.cpp
@@ -21,7 +21,10 @@
 #include "fileoperationdialog.h"
 #include "fileoperation.h"
 #include "renamedialog.h"
+#include <QLabel>
 #include <QMessageBox>
+#include <libfm/fm-config.h>
+#include "utilities.h"
 #include "ui_file-operation-dialog.h"
 
 namespace Fm {
@@ -150,6 +153,12 @@ FmJobErrorAction FileOperationDialog::error(GError* err, FmJobErrorSeverity seve
 
 void FileOperationDialog::setCurFile(QString cur_file) {
     ui->curFile->setText(cur_file);
+}
+
+void FileOperationDialog::setDataTransferred(uint64_t finishedSize, std::uint64_t totalSize) {
+    ui->dataTransferred->setText(QString("%1 / %2")
+                                 .arg(formatFileSize(finishedSize, fm_config->si_unit))
+                                 .arg(formatFileSize(totalSize, fm_config->si_unit)));
 }
 
 void FileOperationDialog::setPercent(unsigned int percent) {

--- a/src/fileoperationdialog.h
+++ b/src/fileoperationdialog.h
@@ -22,6 +22,7 @@
 #define FM_FILEOPERATIONDIALOG_H
 
 #include "libfmqtglobals.h"
+#include <cstdint>
 #include <QDialog>
 #include <libfm/fm.h>
 #include "core/filepath.h"
@@ -50,6 +51,7 @@ public:
     void setPrepared();
     void setCurFile(QString cur_file);
     void setPercent(unsigned int percent);
+    void setDataTransferred(std::uint64_t finishedSize, std::uint64_t totalSize);
     void setRemainingTime(unsigned int sec);
 
     virtual void reject();


### PR DESCRIPTION
When performing long-running file operations, it is helpful to be able to see the amount of data being transferred in addition to the progress and estimated time remaining. This pull request adds such a feature:

![screenshot_20171018_145027](https://user-images.githubusercontent.com/1253444/31754753-b3c4c68e-b44e-11e7-90ab-f7b68d381275.png)
