### PR TITLE
Smooth scrolling for icon and thumbnail views

### DIFF
--- a/src/folderview.h
+++ b/src/folderview.h
@@ -160,6 +160,7 @@ private Q_SLOTS:
     void onAutoSelectionTimeout();
     void onSelChangedTimeout();
     void onClosingEditor(QWidget* editor, QAbstractItemDelegate::EndEditHint hint);
+    void scrollSmoothly();
 
 Q_SIGNALS:
     void clicked(int type, const std::shared_ptr<const Fm::FileInfo>& file);
@@ -181,6 +182,14 @@ private:
     QTimer* selChangedTimer_;
     // the cell margins in the icon and thumbnail modes
     QSize itemDelegateMargins_;
+    // smooth scrolling:
+    struct scollData {
+        int delta;
+        int leftFrames;
+    };
+    QTimer *smoothScrollTimer_;
+    QWheelEvent *wheelEvent_;
+    QList<scollData> queuedScrollSteps_;
 };
 
 }


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/579.

The smooth wheel scrolling is implemented when the cursor is inside the icon/thumbnail view. The scrolling is as before (jumpy) when the cursor is on the scrollbar, so that both options are available to the user.

The CPU usage is optimized by disabling the animation when the wheel speed is too high. Unlike in Dolphin, the animation respects the number of scroll lines per wheel turn, as set in the LXQt configuration.

NOTES:
(1) **pcmanfm-qt should be recompiled after this; otherwise, it will most probably crash.**
(2) A partial workaround could be added for Qt5's scroll jump bug but I did not do so here because of the subject.