### PR TITLE
Merge side-pane with its surroundings

### DIFF
--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -38,6 +38,13 @@ PlacesView::PlacesView(QWidget* parent):
     setHeaderHidden(true);
     setIndentation(12);
 
+    /* merge with the surroundings */
+    setFrameShape(QFrame::NoFrame);
+    QPalette p = palette();
+    p.setColor(QPalette::Base, QColor(Qt::transparent));
+    setPalette(p);
+    viewport()->setAutoFillBackground(false);
+
     connect(this, &QTreeView::clicked, this, &PlacesView::onClicked);
     connect(this, &QTreeView::pressed, this, &PlacesView::onPressed);
 


### PR DESCRIPTION
Closes https://github.com/lxde/pcmanfm-qt/issues/583.

This makes sidepanes transparent -- whether in pcmanfm-qt or in LXQt file dialog -- creating a more professional look, as in KDE.

The tree-view side-pane isn't touched because otherwise, tree-lines would be invisible in themes that have them.