### PR TITLE
Fix wrong gray-out of cut files

### DIFF
--- a/src/folderview.cpp
+++ b/src/folderview.cpp
@@ -1218,8 +1218,10 @@ void FolderView::onClipboardDataChange() {
         if(!folder()->path().hasUriScheme("search") // skip for search results
            && isCutSelection
            && Fm::isCurrentPidClipboardData(*data)) { // set cut files only with this app
-            auto cutDirPath = paths.size() > 0 ? paths[0].parent(): FilePath();
-            if(folder()->path() == cutDirPath) {
+            auto cutDirPath = paths.size() > 0 ? paths[0].parent() : FilePath();
+            // set the cut file(s) only if the cutting is done here
+            if(folder()->path() == cutDirPath
+               && selectedFilePaths() == paths) {
                 model_->setCutFiles(selectionModel()->selection());
             }
             else if(folder()->hadCutFilesUnset() || folder()->hasCutFiles()) {


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/596.

The selected files of a folder are cut only if their paths are equal to the cut paths. Otherwise, the selection shouldn't be used to gray out items. Previously, the selection was always used to gray out items and that resulted in a wrong gray-out when a folder was opened in more than one tab/window.