### PR TITLE
Prevent a potential crash in xdndworkaround

### DIFF
--- a/src/xdndworkaround.h
+++ b/src/xdndworkaround.h
@@ -52,6 +52,7 @@
 #include <QAbstractNativeEventFilter>
 #include <xcb/xcb.h>
 #include <QByteArray>
+#include <QPointer>
 
 class QDrag;
 
@@ -77,7 +78,7 @@ private:
     // _QBasicDrag* xcbDrag() const;
     void buttonRelease();
 
-    QDrag* lastDrag_;
+    QPointer<QDrag> lastDrag_;
     // xinput related
     bool xinput2Enabled_;
     int xinputOpCode_;


### PR DESCRIPTION
The pointer `lastDrag_`, which is used by `xdndworkaround.cpp` to keep track of the last drag, may become dangling in the meanwhile (when used in `dndWorkaround::selectionRequest`) and cause a crash. To prevent that, `QPointer` is used.

NOTES:
(1) Without tab DND, there was no chance for `lastDrag_` to become a dangling pointer. However, `QPointer` is always safer.
(2) Before this patch, I could reproduce a crash only under Enlightenment (it's a good environment for finding hidden issues because of its unusual ways of handling X).