### PR TITLE
Really cancel multiple renaming on cancelling

### DIFF
--- a/src/filemenu.cpp
+++ b/src/filemenu.cpp
@@ -376,7 +376,9 @@ void FileMenu::onRenameTriggered() {
         }
     }
     for(auto& info: files_) {
-        Fm::renameFile(info, nullptr);
+        if(!Fm::renameFile(info, nullptr)) {
+            break;
+        }
     }
 }
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -169,7 +169,7 @@ void changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidge
     }
 }
 
-void renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {
+bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {
     FilenameDialog dlg(parent);
     dlg.setWindowTitle(QObject::tr("Rename File"));
     dlg.setLabelText(QObject::tr("Please enter a new name:"));
@@ -182,14 +182,15 @@ void renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {
     }
 
     if(dlg.exec() != QDialog::Accepted) {
-        return;
+        return false; // stop multiple renaming
     }
 
     QString new_name = dlg.textValue();
     if(new_name == old_name) {
-        return;
+        return true; // let multiple renaming continue
     }
     changeFileName(file->path(), new_name, parent);
+    return true;
 }
 
 // templateFile is a file path used as a template of the new file.

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -55,7 +55,7 @@ LIBFM_QT_API bool isCurrentPidClipboardData(const QMimeData& data);
 
 LIBFM_QT_API void changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent);
 
-LIBFM_QT_API void renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = 0);
+LIBFM_QT_API bool renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = 0);
 
 enum CreateFileType {
     CreateNewFolder,


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/597

Previously, there was no easy way to cancel renaming of a great number of files because pressing Cancel/Esc just canceled renaming of the current file while that could also be achieved by pressing OK/Enter without changing the name.

A PR will follow this for renaming through pcmanfm-qt's Edit menu and also with shortcut.