### PR TITLE
FileInfo: Fix potential SEGFAULT

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -28,7 +28,8 @@ void FileInfo::setFromGFileInfo(const GObjectPtr<GFileInfo>& inf, const FilePath
     GIcon* gicon;
     GFileType type;
 
-    name_ = g_file_info_get_name(inf.get());
+    if (const char * name = g_file_info_get_name(inf.get()))
+        name_ = name;
 
     dispName_ = g_file_info_get_display_name(inf.get());
 


### PR DESCRIPTION
..as the g_file_info_get_name() can return nullptr, which leads to
SEGFAULT in the std::string's assignment operator.

fixes #132