### PR TITLE
No change queue of files in the deletion queue

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -346,10 +346,10 @@ bool Folder::eventFileAdded(const FilePath &path) {
 bool Folder::eventFileChanged(const FilePath &path) {
     bool added;
     // G_LOCK(lists);
-    /* make sure that the file is not already queued for changes or
-     * it's already queued for addition. */
+    /* make sure that the file is not already queued for changes, addition or deletion */
     if(std::find(paths_to_update.cbegin(), paths_to_update.cend(), path) == paths_to_update.cend()
-       && std::find(paths_to_add.cbegin(), paths_to_add.cend(), path) == paths_to_add.cend()) {
+       && std::find(paths_to_add.cbegin(), paths_to_add.cend(), path) == paths_to_add.cend()
+       && std::find(paths_to_del.cbegin(), paths_to_del.cend(), path) == paths_to_del.cend()) {
         /* Since this function is called only when a file already exists, even if that file
            isn't included in "files_" yet, it will be soon due to a previous call to queueUpdate().
            So, here, we should queue it for changes regardless of what "files_" may contain. */


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/508

Apparently, `GFileMonitor` may issue `G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED/G_FILE_MONITOR_EVENT_CHANGED` after `G_FILE_MONITOR_EVENT_DELETED`. However, if a file is queued for change after being queued for deletion, its item might not be removed. The current patch prevents such a scenario.