### PR TITLE
Prepare libfm-qt for bulk rename

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -156,7 +156,7 @@ bool isCurrentPidClipboardData(const QMimeData& data) {
     return !clip_pid.isEmpty() && clip_pid == curr_pid;
 }
 
-void changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidget* parent) {
+bool changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidget* parent, bool showMessage) {
     auto dest = filePath.parent().child(newName.toLocal8Bit().constData());
     Fm::GErrorPtr err;
     if(!g_file_move(filePath.gfile().get(), dest.gfile().get(),
@@ -165,8 +165,12 @@ void changeFileName(const Fm::FilePath& filePath, const QString& newName, QWidge
                                    G_FILE_COPY_NOFOLLOW_SYMLINKS),
                     nullptr, /* make this cancellable later. */
                     nullptr, nullptr, &err)) {
-        QMessageBox::critical(parent, QObject::tr("Error"), err.message());
+        if (showMessage){
+            QMessageBox::critical(parent, QObject::tr("Error"), err.message());
+        }
+        return false;
     }
+    return true;
 }
 
 void renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent) {

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -53,7 +53,7 @@ LIBFM_QT_API void cutFilesToClipboard(const Fm::FilePathList& files);
 
 LIBFM_QT_API bool isCurrentPidClipboardData(const QMimeData& data);
 
-LIBFM_QT_API void changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent);
+LIBFM_QT_API bool changeFileName(const Fm::FilePath& path, const QString& newName, QWidget* parent, bool showMessage = true);
 
 LIBFM_QT_API void renameFile(std::shared_ptr<const Fm::FileInfo> file, QWidget* parent = 0);
 


### PR DESCRIPTION
This will be used and followed by a PR for bulk rename in pcmanfm-qt. `changeFileName()` returns `true` only if renaming is successful and shows an error message only if needed. The changes are backward compatible.

NOTE: Bulk rename is not included in libfm-qt itself because only a file manager may need it.