### PR TITLE
No cut path with search directory

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -477,7 +477,9 @@ void Folder::setCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet) 
     if(cutFilesHashSet_ && !cutFilesHashSet_->empty()) {
         lastCutFilesDirPath_ = cutFilesDirPath_;
     }
-    cutFilesDirPath_ = dirPath_;
+    if(!dirPath_.hasUriScheme("search")) { // the search:/// dir doesn't support file monitoring
+        cutFilesDirPath_ = dirPath_;
+    }
     cutFilesHashSet_ = cutFilesHashSet;
 }
 
@@ -496,8 +498,8 @@ void Folder::onDirListFinished() {
     std::vector<FileInfoPair> files_to_update;
     const auto& infos = job->files();
 
-    // with "search://", there is no update for infos and all of them should be added
-    if(strcmp(dirPath_.uriScheme().get(), "search") == 0) {
+    // with search:///, there is no update for infos and all of them should be added
+    if(dirPath_.hasUriScheme("search")) {
         files_to_add = infos;
         for(auto& file: files_to_add) {
             files_[file->name()] = file;


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/603

For the search directory, setting the (static) cut path has no meaning because that directory doesn't support file monitoring. On the other hand, if the cut path is set, a crash will happen on quitting because the GFile that's stored in the path is already unreferenced (how?) but `__do_global_dtors_aux()` tries to unref it again.