### PR TITLE
Track folders containing cut files only with QString

### DIFF
--- a/src/core/folder.cpp
+++ b/src/core/folder.cpp
@@ -34,8 +34,8 @@
 namespace Fm {
 
 std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> Folder::cache_;
-FilePath Folder::cutFilesDirPath_;
-FilePath Folder::lastCutFilesDirPath_;
+QString Folder::cutFilesDirPath_;
+QString Folder::lastCutFilesDirPath_;
 std::shared_ptr<const HashSet> Folder::cutFilesHashSet_;
 std::mutex Folder::mutex_;
 
@@ -460,8 +460,8 @@ void Folder::onFileChangeEvents(GFileMonitor* /*monitor*/, GFile* gf, GFile* /*o
 // checks whether there were cut files here
 // and if there were, invalidates this last cut path
 bool Folder::hadCutFilesUnset() {
-    if(lastCutFilesDirPath_ == dirPath_) {
-        lastCutFilesDirPath_ = FilePath();
+    if(lastCutFilesDirPath_ == dirPath_.toString().get()) {
+        lastCutFilesDirPath_ = QString();
         return true;
     }
     return false;
@@ -470,14 +470,14 @@ bool Folder::hadCutFilesUnset() {
 bool Folder::hasCutFiles() {
     return cutFilesHashSet_
             && !cutFilesHashSet_->empty()
-            && cutFilesDirPath_ == dirPath_;
+            && cutFilesDirPath_ == dirPath_.toString().get();
 }
 
 void Folder::setCutFiles(const std::shared_ptr<const HashSet>& cutFilesHashSet) {
     if(cutFilesHashSet_ && !cutFilesHashSet_->empty()) {
         lastCutFilesDirPath_ = cutFilesDirPath_;
     }
-    cutFilesDirPath_ = dirPath_;
+    cutFilesDirPath_ = dirPath_.toString().get();
     cutFilesHashSet_ = cutFilesHashSet;
 }
 

--- a/src/core/folder.h
+++ b/src/core/folder.h
@@ -185,8 +185,8 @@ private:
     bool defer_content_test : 1;
 
     static std::unordered_map<FilePath, std::weak_ptr<Folder>, FilePathHash> cache_;
-    static FilePath cutFilesDirPath_;
-    static FilePath lastCutFilesDirPath_;
+    static QString cutFilesDirPath_;
+    static QString lastCutFilesDirPath_;
     static std::shared_ptr<const HashSet> cutFilesHashSet_;
     static std::mutex mutex_;
 };


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/603

`QString` is used, instead of `Fm:FilePath`, for tracking folders with cut files.

The reason is that a static `Fm:FilePath` can cause a crash on quitting because the `GFile` that's stored in it may already have a zero reference count when `__do_global_dtors_aux()` tries to unref it. QString is completely safe in this regard.