### PR TITLE
Copy selected pathbar text to selection clipboard

### DIFF
--- a/src/pathbar.cpp
+++ b/src/pathbar.cpp
@@ -305,8 +305,9 @@ void PathBar::openEditor() {
         connect(tempPathEdit_, &PathEdit::returnPressed, this, &PathBar::onReturnPressed);
         connect(tempPathEdit_, &PathEdit::editingFinished, this, &PathBar::closeEditor);
     }
-    tempPathEdit_->setFocus();
     tempPathEdit_->selectAll();
+    QApplication::clipboard()->setText(tempPathEdit_->text(), QClipboard::Selection);
+    QTimer::singleShot(0, tempPathEdit_, SLOT(setFocus()));
 }
 
 void PathBar::closeEditor() {


### PR DESCRIPTION
Closes https://github.com/lxde/pcmanfm-qt/issues/604

Also use `QTimer::singleSho()` to focus the line-edit because otherwise, it might not have time to get focused if the main window didn't have focus (this can happen with some window managers like Enlightenment's).