### PR TITLE
Fixed the logic of queued deletion

### DIFF
--- a/src/core/fileinfojob.cpp
+++ b/src/core/fileinfojob.cpp
@@ -3,9 +3,10 @@
 
 namespace Fm {
 
-FileInfoJob::FileInfoJob(FilePathList paths, FilePath commonDirPath, const std::shared_ptr<const HashSet>& cutFilesHashSet):
+FileInfoJob::FileInfoJob(FilePathList paths, FilePathList deletionPaths, FilePath commonDirPath, const std::shared_ptr<const HashSet>& cutFilesHashSet):
     Job(),
     paths_{std::move(paths)},
+    deletionPaths_{std::move(deletionPaths)},
     commonDirPath_{std::move(commonDirPath)},
     cutFilesHashSet_{cutFilesHashSet} {
 }
@@ -19,8 +20,9 @@ void FileInfoJob::exec() {
                                   G_FILE_QUERY_INFO_NONE, cancellable().get(), &err),
                 false
             };
-            if(!inf)
-                return;
+            if(!inf) {
+                continue;
+            }
 
             // Reuse the same dirPath object when the path remains the same (optimize for files in the same dir)
             auto dirPath = commonDirPath_.isValid() ? commonDirPath_ : path.parent();

--- a/src/core/fileinfojob.h
+++ b/src/core/fileinfojob.h
@@ -13,10 +13,14 @@ class LIBFM_QT_API FileInfoJob : public Job {
     Q_OBJECT
 public:
 
-    explicit FileInfoJob(FilePathList paths, FilePath commonDirPath = FilePath(), const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
+    explicit FileInfoJob(FilePathList paths, FilePathList deletionPaths = FilePathList(), FilePath commonDirPath = FilePath(), const std::shared_ptr<const HashSet>& cutFilesHashSet = nullptr);
 
     const FilePathList& paths() const {
         return paths_;
+    }
+
+    const FilePathList& deletionPaths() const {
+        return deletionPaths_;
     }
 
     const FileInfoList& files() const {
@@ -31,6 +35,7 @@ protected:
 
 private:
     FilePathList paths_;
+    FilePathList deletionPaths_;
     FileInfoList results_;
     FilePath commonDirPath_;
     const std::shared_ptr<const HashSet> cutFilesHashSet_;


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/508.

Queueing files for deletion was done inaccurately before.

First, as was the case with the update queue (see https://github.com/lxde/libfm-qt/commit/90531712fe05e96488ccd8fcfd29a618b49eb65c and https://github.com/lxde/pcmanfm-qt/issues/506), the deletion queue should not rely on the files that are listed *at the moment* because the order of some function calls isn't fixed -- the function `core/folder.cpp → Folder::processPendingChanges()` may be called multiple times without a single call to `Folder::onFileInfoFinished()` (although that's rare).

Second, and for the same reason, the deletion should be done only *after* the file info job is finished and processed by `Folder::onFileInfoFinished()`; otherwise, the order of addition, update and deletion might be wrong and, as a side effect, nonexistent files might be shown. Therefore, `FileInfoJob` should carry the deletion paths as an additional variable.

Also removed a redundant call (not important).