### PR TITLE
Add Group column and don't use owner's full name

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -229,6 +229,8 @@ QVariant FolderModel::data(const QModelIndex& index, int role/* = Qt::DisplayRol
             return item->displaySize();
         case ColumnFileOwner:
             return item->ownerName();
+        case ColumnFileGroup:
+            return item->ownerGroup();
         }
         break;
     }
@@ -273,6 +275,9 @@ QVariant FolderModel::headerData(int section, Qt::Orientation orientation, int r
                 break;
             case ColumnFileOwner:
                 title = tr("Owner");
+                break;
+            case ColumnFileGroup:
+                title = tr("Group");
                 break;
             }
             return QVariant(title);

--- a/src/foldermodel.h
+++ b/src/foldermodel.h
@@ -54,6 +54,7 @@ public:
         ColumnFileSize,
         ColumnFileMTime,
         ColumnFileOwner,
+        ColumnFileGroup,
         NumOfColumns
     };
 

--- a/src/foldermodelitem.cpp
+++ b/src/foldermodelitem.cpp
@@ -43,10 +43,7 @@ QString FolderModelItem::ownerName() const {
     QString name;
     auto user = Fm::UserInfoCache::globalInstance()->userFromId(info->uid());
     if(user) {
-        name = user->realName();
-        if(name.isEmpty()) {
-            name = user->name();
-        }
+        name = user->name();
     }
     return name;
 }


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/617.

In the detailed list mode, the owner's full name doesn't seem practical, while a Group column makes the details more complete.

NOTE: pcmanfm-qt should be recompiled after this.