### PR TITLE
Support hiding items in Places side-pane

### DIFF
--- a/src/placesmodel.cpp
+++ b/src/placesmodel.cpp
@@ -55,34 +55,25 @@ PlacesModel::PlacesModel(QObject* parent):
 
     createTrashItem();
 
-    // FIXME: add an option to hide network:///
-    if(true) {
-        computerItem = new PlacesModelItem("computer", tr("Computer"), Fm::FilePath::fromUri("computer:///"));
-        placesRoot->appendRow(computerItem);
-    }
-    else {
-        computerItem = nullptr;
+    computerItem = new PlacesModelItem("computer", tr("Computer"), Fm::FilePath::fromUri("computer:///"));
+    placesRoot->appendRow(computerItem);
+
+    { // Applications
+        const char* applicaion_icon_names[] = {"system-software-install", "applications-accessories", "application-x-executable"};
+        // NOTE: g_themed_icon_new_from_names() accepts char**, but actually const char** is OK.
+        Fm::GIconPtr gicon{g_themed_icon_new_from_names((char**)applicaion_icon_names, G_N_ELEMENTS(applicaion_icon_names)), false};
+        auto fmicon = Fm::IconInfo::fromGIcon(std::move(gicon));
+        applicationsItem = new PlacesModelItem(fmicon, tr("Applications"), Fm::FilePath::fromUri("menu:///applications/"));
+        placesRoot->appendRow(applicationsItem);
     }
 
-    // FIXME: add an option to hide applications:///
-    const char* applicaion_icon_names[] = {"system-software-install", "applications-accessories", "application-x-executable"};
-    // NOTE: g_themed_icon_new_from_names() accepts char**, but actually const char** is OK.
-    Fm::GIconPtr gicon{g_themed_icon_new_from_names((char**)applicaion_icon_names, G_N_ELEMENTS(applicaion_icon_names)), false};
-    auto fmicon = Fm::IconInfo::fromGIcon(std::move(gicon));
-    applicationsItem = new PlacesModelItem(fmicon, tr("Applications"), Fm::FilePath::fromUri("menu:///applications/"));
-    placesRoot->appendRow(applicationsItem);
-
-    // FIXME: add an option to hide network:///
-    if(true) {
+    { // Network
         const char* network_icon_names[] = {"network", "folder-network", "folder"};
         // NOTE: g_themed_icon_new_from_names() accepts char**, but actually const char** is OK.
         Fm::GIconPtr gicon{g_themed_icon_new_from_names((char**)network_icon_names, G_N_ELEMENTS(network_icon_names)), false};
         auto fmicon = Fm::IconInfo::fromGIcon(std::move(gicon));
         networkItem = new PlacesModelItem(fmicon, tr("Network"), Fm::FilePath::fromUri("network:///"));
         placesRoot->appendRow(networkItem);
-    }
-    else {
-        networkItem = nullptr;
     }
 
     devicesRoot = new QStandardItem(tr("Devices"));

--- a/src/placesview.cpp
+++ b/src/placesview.cpp
@@ -415,8 +415,8 @@ void PlacesView::onRenameBookmark() {
     }
     PlacesModelBookmarkItem* item = static_cast<PlacesModelBookmarkItem*>(model_->itemFromIndex(action->index()));
     setFocus();
-    setCurrentIndex(item->index());
-    edit(item->index());
+    setCurrentIndex(proxyModel_->mapFromSource(item->index()));
+    edit(proxyModel_->mapFromSource(item->index()));
 }
 
 void PlacesView::onMountVolume() {

--- a/src/sidepane.cpp
+++ b/src/sidepane.cpp
@@ -64,6 +64,7 @@ void SidePane::setIconSize(QSize size) {
     switch(mode_) {
     case ModePlaces:
         static_cast<PlacesView*>(view_)->setIconSize(size);
+        /* Falls through. */
     case ModeDirTree:
         static_cast<QTreeView*>(view_)->setIconSize(size);
         break;
@@ -159,9 +160,11 @@ void SidePane::setMode(Mode mode) {
     case ModePlaces: {
         PlacesView* placesView = new Fm::PlacesView(this);
         view_ = placesView;
+        placesView->restoreHiddenItems(restorableHiddenPlaces_);
         placesView->setIconSize(iconSize_);
         placesView->setCurrentPath(currentPath_);
         connect(placesView, &PlacesView::chdirRequested, this, &SidePane::chdirRequested);
+        connect(placesView, &PlacesView::hiddenItemSet, this, &SidePane::hiddenPlaceSet);
         break;
     }
     case ModeDirTree: {
@@ -205,6 +208,15 @@ void SidePane::setShowHidden(bool show_hidden) {
         if(model) {
             model->setShowHidden(showHidden_);
         }
+    }
+}
+
+void SidePane::restoreHiddenPlaces(const QSet<QString>& items) {
+    if(mode_ == ModePlaces) {
+        static_cast<PlacesView*>(view_)->restoreHiddenItems(items);
+    }
+    else {
+        restorableHiddenPlaces_.unite(items);
     }
 }
 

--- a/src/sidepane.h
+++ b/src/sidepane.h
@@ -98,6 +98,8 @@ public:
         setCurrentPath(std::move(path));
     }
 
+    void restoreHiddenPlaces(const QSet<QString>& items);
+
 Q_SIGNALS:
     void chdirRequested(int type, const Fm::FilePath& path);
     void openFolderInNewWindowRequested(const Fm::FilePath& path);
@@ -107,6 +109,8 @@ Q_SIGNALS:
     void modeChanged(Fm::SidePane::Mode mode);
 
     void prepareFileMenu(Fm::FileMenu* menu); // emit before showing a Fm::FileMenu
+
+    void hiddenPlaceSet(const QString& str, bool hide);
 
 protected Q_SLOTS:
     void onComboCurrentIndexChanged(int current);
@@ -122,6 +126,7 @@ private:
     QSize iconSize_;
     Mode mode_;
     bool showHidden_;
+    QSet<QString> restorableHiddenPlaces_;
 };
 
 }


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/580.

The items can be hidden by using their context menus. If at least one item is hidden, all rows -- including the root ones (Places, Devices, Bookmarks) -- will have the checkbox "Show All Entries" in their context menus, so that the user could un-hide each hidden item again.

All items can be hidden, except for bookmarks. IMO, hiding bookmarks doesn't make much sense because if they aren't needed, they could be removed.

If all children of a root item are hidden, it'll be hidden too.

Hidden items are remembered during the session. For remembering them between sessions, a pcmanfm-qt PR will follow this one.

Also, the "Empty Trash" menu-item is moved to the top for easier access (as in Dolphin) and is disabled when the trash is empty. Change your habits ;)

NOTE: pcmanfm-qt should be recompiled after this.