### PR TITLE
Ensure that rename editor has opaque background

### DIFF
--- a/src/folderitemdelegate.cpp
+++ b/src/folderitemdelegate.cpp
@@ -350,8 +350,13 @@ QWidget* FolderItemDelegate::createEditor(QWidget* parent, const QStyleOptionVie
         return textEdit;
     }
     else {
-        // return the default line-edit in compact view
-        return QStyledItemDelegate::createEditor(parent, option, index);
+        // return the default line-edit in other views and
+        // ensure that its background isn't transparent (on the side-pane)
+        QWidget* editor = QStyledItemDelegate::createEditor(parent, option, index);
+        QPalette p = editor->palette();
+        p.setColor(QPalette::Base, QApplication::palette().color(QPalette::Base));
+        editor->setPalette(p);
+        return editor;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/630.

Depending on how line-edits are drawn by different widget styles, their background may be transparent with some styles (Fusion and Breeze) on the side-pane because the base color of the side-pane is transparent. This patch guarantees an opaque bg with all styles.