### PR TITLE
Also see `.bak` and `.old` as backup extensions

### DIFF
--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -247,7 +247,11 @@ _file_is_symlink:
     atime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_ACCESS);
     ctime_ = g_file_info_get_attribute_uint64(inf.get(), G_FILE_ATTRIBUTE_TIME_CHANGED);
     isHidden_ = g_file_info_get_is_hidden(inf.get());
-    isBackup_ = g_file_info_get_is_backup(inf.get());
+    // g_file_info_get_is_backup() does not cover ".bak" and ".old".
+    // NOTE: Here, dispName_ is not modified for desktop entries yet.
+    isBackup_ = g_file_info_get_is_backup(inf.get())
+                || dispName_.endsWith(QLatin1String(".bak"))
+                || dispName_.endsWith(QLatin1String(".old"));
     isNameChangeable_ = true; /* GVFS tends to ignore this attribute */
     isIconChangeable_ = isHiddenChangeable_ = false;
     if(g_file_info_has_attribute(inf.get(), G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME)) {

--- a/src/proxyfoldermodel.cpp
+++ b/src/proxyfoldermodel.cpp
@@ -115,10 +115,9 @@ void ProxyFolderModel::setSortCaseSensitivity(Qt::CaseSensitivity cs) {
 
 bool ProxyFolderModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const {
     if(!showHidden_) {
-        QAbstractItemModel* srcModel = sourceModel();
-        QString name = srcModel->data(srcModel->index(source_row, 0, source_parent)).toString();
-        if(name.startsWith(QLatin1Char('.'))
-           || (backupAsHidden_ && name.endsWith(QLatin1Char('~')))) {
+        FolderModel* srcModel = static_cast<FolderModel*>(sourceModel());
+        auto info = srcModel->fileInfoFromIndex(srcModel->index(source_row, 0, source_parent));
+        if(info && (info->isHidden() || (backupAsHidden_ && info->isBackup()))) {
             return false;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/615 and https://github.com/lxde/pcmanfm-qt/issues/633

(1) Previously, only the files whose names ended with `~` were seen as backup files (when backup was treated as hidden).

(2) Also, instead of searching for a dot at the beginning of a file name, consult GLib through `FileInfo` to know if a file is hidden because GLib not only considers dots but also takes the file `.hidden` into account (and more).