### PR TITLE
Don't drop on files

### DIFF
--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -365,7 +365,7 @@ QList< FolderModelItem >::iterator FolderModel::findItemByFileInfo(const Fm::Fil
 }
 
 QStringList FolderModel::mimeTypes() const {
-    qDebug("FolderModel::mimeTypes");
+    //qDebug("FolderModel::mimeTypes");
     QStringList types = QAbstractItemModel::mimeTypes();
     // now types contains "application/x-qabstractitemmodeldatalist"
 
@@ -380,7 +380,7 @@ QStringList FolderModel::mimeTypes() const {
 
 QMimeData* FolderModel::mimeData(const QModelIndexList& indexes) const {
     QMimeData* data = QAbstractItemModel::mimeData(indexes);
-    qDebug("FolderModel::mimeData");
+    //qDebug("FolderModel::mimeData");
     // build a uri list
     QByteArray urilist;
     urilist.reserve(4096);
@@ -402,7 +402,7 @@ QMimeData* FolderModel::mimeData(const QModelIndexList& indexes) const {
 }
 
 bool FolderModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) {
-    qDebug("FolderModel::dropMimeData");
+    //qDebug("FolderModel::dropMimeData");
     if(!folder_ || !data) {
         return false;
     }
@@ -417,7 +417,12 @@ bool FolderModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int
             info = fileInfoFromIndex(itemIndex);
         }
         if(info) {
-            destPath = info->path();
+            if (info->isDir()) {
+                destPath = info->path();
+            }
+            else {
+                destPath = path(); // don't drop on file
+            }
         }
         else {
             return false;
@@ -429,7 +434,7 @@ bool FolderModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int
 
     // FIXME: should we put this in dropEvent handler of FolderView instead?
     if(data->hasUrls()) {
-        qDebug("drop action: %d", action);
+        //qDebug("drop action: %d", action);
         auto srcPaths = pathListFromQUrls(data->urls());
         switch(action) {
         case Qt::CopyAction:
@@ -452,7 +457,7 @@ bool FolderModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int
 }
 
 Qt::DropActions FolderModel::supportedDropActions() const {
-    qDebug("FolderModel::supportedDropActions");
+    //qDebug("FolderModel::supportedDropActions");
     return Qt::CopyAction | Qt::MoveAction | Qt::LinkAction;
 }
 


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/639.

Instead of trying to drop on a file and showing an error message afterward, drop into its containing folder.

Also commented out `qDebug` messages.