### PR TITLE
Prevent possible c++11 range-loop container detach

### DIFF
--- a/src/filedialog.cpp
+++ b/src/filedialog.cpp
@@ -767,7 +767,8 @@ void FileDialog::setMimeTypeFilters(const QStringList& filters) {
         auto nameFilter = mimeType.comment();
         if(!mimeType.suffixes().empty()) {
             nameFilter + " (";
-            for(const auto& suffix: mimeType.suffixes()) {
+            const auto suffixes = mimeType.suffixes();
+            for(const auto& suffix: suffixes) {
                 nameFilter += "*.";
                 nameFilter += suffix;
                 nameFilter += ' ';

--- a/src/foldermodel.cpp
+++ b/src/foldermodel.cpp
@@ -160,7 +160,8 @@ void FolderModel::setCutFiles(const QItemSelection& selection) {
         if(!selection.isEmpty()) {
             auto cutFilesHashSet = std::make_shared<HashSet>();
             folder_->setCutFiles(cutFilesHashSet);
-            for(const auto& index : selection.indexes()) {
+            const auto indexes = selection.indexes();
+            for(const auto& index : indexes) {
                 auto item = itemFromIndex(index);
                 item->bindCutFiles(cutFilesHashSet);
                 cutFilesHashSet->insert(item->info->path().hash());


### PR DESCRIPTION
Deep copies are expensive.