### PR TITLE
Fixed custom action execution mode

### DIFF
--- a/src/customactions/fileactionprofile.cpp
+++ b/src/customactions/fileactionprofile.cpp
@@ -32,6 +32,9 @@ FileActionProfile::FileActionProfile(GKeyFile *kf, const char* profile_name) {
             exec_mode = FileActionExecMode::NORMAL;
         }
     }
+    else {
+        exec_mode = FileActionExecMode::NORMAL;
+    }
 
     startup_notify = g_key_file_get_boolean(kf, group_name.c_str(), "StartupNotify", nullptr);
     startup_wm_class = CStrPtr{g_key_file_get_string(kf, group_name.c_str(), "StartupWMClass", nullptr)};


### PR DESCRIPTION
The variable `exec_mode` wasn't initialized when the action lacked "ExecutionMode" (which is the case most of the time).

Strange that, previously, it always worked, although it shouldn't! Only today I saw an effect of this problem (which wasn't a crash).